### PR TITLE
Improving the Command Line for training parameters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
         "savefig",
         "scikit",
         "searchsorted",
+        "shirtballs",
         "sklearn",
         "softmax",
         "Sover",

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 import fsspec
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, Field
 import yaml
 
 # WARNING:
@@ -14,8 +14,17 @@ class TrainingConfig(BaseModel):
     """Configuration to run a complete training, from source data files on!"""
 
     # Name of the model - for user reference only
-    model_name: Optional[str]
+    model_name: Optional[str] = Field(
+        description="Name of the model - for user reference only"
+    )
+
+    # TODO: Why do we have two learning rates?
     learning_rate: Optional[float]
+    # NAdam learning rate.
+    lr_values: Optional[float] = Field(
+        description="NAdam learning rate for both main network and adversary"
+    )
+
     filters_cnn_constit: Optional[List[int]]
     frac_list: Optional[float]
     nodes_constit_lstm: Optional[int]
@@ -27,15 +36,13 @@ class TrainingConfig(BaseModel):
     nodes_track_lstm: Optional[int]
     filters_cnn_MSeg: Optional[List[int]]
     nodes_MSeg_lstm: Optional[int]
-    batch_size: Optional[int]
 
     # Number of epochs for training
     epochs: Optional[int]
     # Number of mini-batches
     num_splits: Optional[int]
-
-    # NAdam learning rate.
-    lr_values: Optional[float]
+    # TODO: Why do we have both batch_size and num_splits?
+    batch_size: Optional[int]
 
     hidden_layer_fraction: Optional[float]
 

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -3,18 +3,17 @@ import logging
 from pathlib import Path
 
 from cal_ratio_trainer.config import load_config
+from cal_ratio_trainer.utils import add_config_args, apply_config_args
 
 
 def do_train(args):
     # Get the config loaded.
-    c = load_config(args.config)
+    c_config = load_config(args.config)
 
     # Next, look at the arguments and see if anything should be changed.
-    if args.epochs is not None:
-        c.epochs = args.epochs
-    if args.num_splits is not None:
-        c.num_splits = args.num_splits
+    c = apply_config_args(c_config, args)
 
+    # Now, run the training.
     from cal_ratio_trainer.training.runner_utils import training_runner_util
 
     training_runner_util(c)
@@ -41,8 +40,7 @@ def main():
         help="Path to the config file to use for training",
     )
     # Add all the training configuration options
-    parser_train.add_argument("--epochs", type=int, help="Number of epochs to train")
-    parser_train.add_argument("--num_splits", type=int, help="Number of mini-batches")
+    add_config_args(parser_train)
     parser_train.set_defaults(func=do_train)
 
     # Parse the command line arguments

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -13,10 +13,17 @@ def do_train(args):
     # Next, look at the arguments and see if anything should be changed.
     c = apply_config_args(c_config, args)
 
-    # Now, run the training.
-    from cal_ratio_trainer.training.runner_utils import training_runner_util
+    # Figure out what to do next
+    if args.print_settings:
+        # Pretty Print the training configuration
+        for k, v in c.dict().items():
+            print(f"{k}: {str(v)}")
+        return
+    else:
+        # Now, run the training.
+        from cal_ratio_trainer.training.runner_utils import training_runner_util
 
-    training_runner_util(c)
+        training_runner_util(c)
 
 
 def main():
@@ -39,6 +46,13 @@ def main():
         type=Path,
         help="Path to the config file to use for training",
     )
+    parser_train.add_argument(
+        "--print-settings",
+        action="store_true",
+        default=False,
+        help="Print the training configuration and exit",
+    )
+
     # Add all the training configuration options
     add_config_args(parser_train)
     parser_train.set_defaults(func=do_train)

--- a/cal_ratio_trainer/utils.py
+++ b/cal_ratio_trainer/utils.py
@@ -1,0 +1,98 @@
+import argparse
+from types import NoneType
+from typing import Generator, Tuple, Union
+from .config import TrainingConfig
+
+
+def as_bare_type(t: type) -> Union[type, None]:
+    """Return the bare type for certain types:
+
+    str, float, int -> return those.
+    Optional[T] -> return T, as long as T is one of the above.
+    Anything else -> return None (too complex, we can't deal with it).
+
+    Args:
+        t (type): The type to convert with the above rules.
+
+    Returns:
+        Union[type, None]: The bare type, or None if can't be found.
+    """
+    if t == str or t == float or t == int:
+        return t
+    elif hasattr(t, "__origin__") and t.__origin__ == Union:  # type: ignore
+        # This is an Optional[T], so we need to get T.
+        # We can only deal with T if it is one of the above types.
+        if len(t.__args__) != 2 and NoneType not in t.__args__:  # type: ignore
+            return None
+        for t2 in t.__args__:  # type: ignore
+            if t2 == str or t2 == float or t2 == int:
+                return t2
+        return None
+    else:
+        return None
+
+
+def _good_config_args() -> Generator[Tuple[str, type], None, None]:
+    """Return the list of training params that are good for being set
+    on the command line (e.g. their types are something we can easily deal
+    with).
+
+    Yields:
+        Generator[str, None, None]: Generates all the names of the good arguments
+    """
+    dummy = TrainingConfig(**{}).dict()
+
+    for prop in dummy.keys():
+        p_type = as_bare_type(TrainingConfig.__annotations__[prop])
+        if p_type is not None:
+            yield prop, p_type
+
+
+def add_config_args(args: argparse.ArgumentParser) -> None:
+    """Add all the configuration arguments to the argument parser.
+
+    This includes adding any help strings that python knows about
+    as the argument help.
+
+    Parameters
+    ----------
+    args : argparse.ArgumentParser
+        The argument parser to add the arguments to.
+    """
+    # Look at the properties of the TrainingConfig object.
+    for prop, p_type in _good_config_args():
+        help_str = (
+            TrainingConfig.__fields__[prop].field_info.description
+            if prop in TrainingConfig.__fields__
+            else None
+        )
+        args.add_argument(
+            f"--{prop}",
+            type=p_type,
+            help=help_str,
+        )
+
+
+def apply_config_args(config: TrainingConfig, args) -> TrainingConfig:
+    """Using args, anything that isn't set to None that matches as config
+    option in TrainingConfig, update TrainingConfig and return a new one.
+
+    Note: The `config` will not be updated - a new one will be returned.
+
+    Args:
+        config (TrainingConfig): The base training config to start from
+        args (_type_): The list of arguments
+
+    Returns:
+        (TrainingConfig): New training config with updated arguments
+    """
+    # Start by making a copy of config for updating.
+    r = TrainingConfig(**config.dict())
+
+    # Next, loop through all possible arguments from the training config.
+    for prop, p_type in _good_config_args():
+        # If the argument is set, then update the config.
+        if getattr(args, prop) is not None:
+            setattr(r, prop, getattr(args, prop))
+
+    return r

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import argparse
+from typing import Any, Dict
+from cal_ratio_trainer.config import TrainingConfig
+
+from cal_ratio_trainer.utils import add_config_args, apply_config_args
+
+
+def test_add_args_right_ones():
+    """Test that the add_config_args function adds the correct arguments."""
+    # Create an argument parser
+    parser = argparse.ArgumentParser()
+    add_config_args(parser)
+
+    # Check that there are a few arguments in the parser that we expect.
+    help = parser.format_help()
+    assert "--model_name" in help
+    assert "--dropout_array" in help
+
+    # Anything with a complex type should not be in the argument parser
+    assert "--filters_cnn_constit" not in help
+
+
+def test_add_args_help_string():
+    """Test that the add_config_args function adds the correct arguments."""
+    # Create an argument parser
+    parser = argparse.ArgumentParser()
+    add_config_args(parser)
+
+    assert "Name of the model" in parser.format_help()
+
+
+def test_update_args():
+    """Test add_config_args to see if it properly updates training config"""
+    arguments: Dict[str, Any] = {"model_name": "forking"}
+    t_orig = TrainingConfig(**arguments)
+
+    # Create an argument parser
+    parser = argparse.ArgumentParser()
+    add_config_args(parser)
+
+    # Now, parse dummy command line with the model_name argument
+    args = parser.parse_args(["--model_name", "shirtballs"])
+
+    # Next, do the update of t_orig.
+    t_final = apply_config_args(t_orig, args)
+
+    # Check the original did not change and the update did occur.
+    assert t_orig.model_name == "forking"
+    assert t_final.model_name == "shirtballs"


### PR DESCRIPTION
* Fixes #23: add all simple trianing parameters to the command line.
* Fixes #22: Add a pring settings option to print out configuration for the run, but not actually run.