### PR TITLE
Remove the parameter `learning_rate`

### DIFF
--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -18,8 +18,6 @@ class TrainingConfig(BaseModel):
         description="Name of the model - for user reference only"
     )
 
-    # TODO: Why do we have two learning rates?
-    learning_rate: Optional[float]
     # NAdam learning rate.
     lr_values: Optional[float] = Field(
         description="NAdam learning rate for both main network and adversary"

--- a/cal_ratio_trainer/default_training_config.yaml
+++ b/cal_ratio_trainer/default_training_config.yaml
@@ -1,5 +1,4 @@
 model_name: RNN_Adversary
-learning_rate: 0.0008
 filters_cnn_constit: [64, 32, 32, 16]
 frac_list: 0.5
 nodes_constit_lstm: 10
@@ -16,7 +15,6 @@ nodes_MSeg_lstm: 5
 batch_size: 512
 epochs: 100
 num_splits: 50
-# TODO: Why is there lr_values and learning_rate?
 lr_values: 0.0008
 hidden_layer_fraction: 1.0
 

--- a/cal_ratio_trainer/training/runner_utils.py
+++ b/cal_ratio_trainer/training/runner_utils.py
@@ -61,7 +61,7 @@ def initialize_model(
     ModelInput,
 ]:
     p_list = [
-        "learning_rate",
+        "lr_values",
         "filters_cnn_constit",
         "frac_list",
         "nodes_constit_lstm",


### PR DESCRIPTION
`learning_rate` wasn't used anywhere, but was in our parameter list. This gets rid of it in the source code.

Fixes #25