### PR TITLE
Fix up file://./ bug

### DIFF
--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -1,7 +1,7 @@
 import io
 from pathlib import Path
 from typing import Dict, List, Optional, Union
-from pydantic import AnyUrl, BaseModel, Field
+from pydantic import BaseModel, Field
 import yaml
 
 # WARNING:
@@ -53,9 +53,9 @@ class TrainingConfig(BaseModel):
     include_high_mass: Optional[bool] = False
 
     # The path to the main training data file (signal, qcd, and bib)
-    # Use "file://xxx" to specify a local file.
-    main_training_file: Optional[AnyUrl] = None
-    cr_training_file: Optional[AnyUrl] = None
+    # Use "file:///xxx" to specify a local file with absolute path on linux.
+    main_training_file: Optional[str] = None
+    cr_training_file: Optional[str] = None
 
     def __str__(self) -> str:
         string_out = io.StringIO()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,3 +22,8 @@ def test_str():
     c = load_config()
     assert "epochs" in str(c)
     assert "\n" in str(c)
+
+
+def test_url():
+    c = load_config(Path("tests/test_with_file_url.yaml"))
+    assert c.main_training_file == "file:///home/gwatts/junk.pkl"

--- a/tests/test_with_file_url.yaml
+++ b/tests/test_with_file_url.yaml
@@ -1,0 +1,1 @@
+main_training_file: "file:///home/gwatts/junk.pkl"


### PR DESCRIPTION
* Shift from AnyUrl to using a string for the URL. AnyURL turns out to not know about a url that is complete when it comes to a `file:` protocal!
* This also also has the side effect of fixing #43

Fixes #44, #43