### PR TITLE
Basic build command boilerplate (#69)

### DIFF
--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -191,6 +191,12 @@ class DiVertAnalysisInputFile(BaseModel):
         description="The type of data in this file. One of 'sig', 'qcd', 'bib'."
     )
 
+    # Output directory name, which is under the `output_path` of the master config.
+    output_dir: Optional[str] = Field(
+        description="The name of the output directory for this file. Stored under the "
+        "`output_path` of the master config."
+    )
+
 
 class ConvertDiVertAnalysisConfig(BaseModel):
     "Configuration for converting a divertanalysis output file"

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -448,6 +448,14 @@ def convert_divert(config: ConvertDiVertAnalysisConfig):
 
     for f_info in config.input_files:
         found_file = False
+
+        # Build the output file directory
+        assert config.output_path is not None
+        output_dir_path = config.output_path
+
+        if f_info.output_dir is not None:
+            output_dir_path = output_dir_path / f_info.output_dir
+
         for file_path in (Path(f) for f in glob.glob(str(f_info.input_file))):
             assert file_path.exists()
             found_file = True
@@ -457,7 +465,8 @@ def convert_divert(config: ConvertDiVertAnalysisConfig):
 
             # The output file is with pkl on it, and in the output directory.
             assert config.output_path is not None
-            output_file = config.output_path / file_path.with_suffix(".pkl").name
+            output_file = output_dir_path / file_path.with_suffix(".pkl").name
+            output_dir_path.mkdir(parents=True, exist_ok=True)
 
             # Now run the requested processing
             with uproot.open(file_path) as in_file:  # type: ignore

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -115,7 +115,9 @@ def do_divert_convert(args):
 
     if len(args.input_files) > 0:
         a.input_files = [
-            DiVertAnalysisInputFile(input_file=f, data_type=args.data_type)
+            DiVertAnalysisInputFile(
+                input_file=f, data_type=args.data_type, output_dir=None
+            )
             for f in args.input_files
         ]
 


### PR DESCRIPTION
This feature is only accessible via `ymal` configuration:

* If for a file or group of files an `output_dir` string is specified, the output file will be written into that directory.

Fixes #72