### PR TITLE
Do not convert a file that already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ timings.txt
 reports/
 model.json
 model.keras
+temp_stateful.keras
+temp_stateless.keras

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -467,6 +467,10 @@ def convert_divert(config: ConvertDiVertAnalysisConfig):
             assert config.output_path is not None
             output_file = output_dir_path / file_path.with_suffix(".pkl").name
 
+            if output_file.exists():
+                logging.info(f"File {output_file} already exists. Skipping.")
+                continue
+
             # Now run the requested processing
             try:
                 with uproot.open(file_path) as in_file:  # type: ignore

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -3,11 +3,12 @@ from cal_ratio_trainer.config import (
     ConvertDiVertAnalysisConfig,
     DiVertAnalysisInputFile,
     DiVertFileType,
+    load_config,
 )
 from cal_ratio_trainer.convert.convert_divert import convert_divert
 
 
-def test_empty_root_files(caplog):
+def test_empty_root_files(caplog, tmp_path):
     "run translation, make sure no crash occurs when a empty file is looked at"
 
     config = ConvertDiVertAnalysisConfig(
@@ -18,7 +19,7 @@ def test_empty_root_files(caplog):
                 output_dir=None,
             )
         ],
-        output_path=Path("./out"),
+        output_path=tmp_path,
         signal_branches=["one", "two"],
         bib_branches=["three", "four"],
         qcd_branches=["five", "six"],
@@ -32,8 +33,9 @@ def test_empty_root_files(caplog):
     assert "0 events" in caplog.text
 
 
-def test_missing_root_files(caplog):
-    "run translation, make sure no crash occurs when a empty file is looked at"
+def test_missing_root_files(caplog, tmp_path):
+    """run translation, make sure no crash occurs when a file with missing columns
+    is looked at"""
 
     config = ConvertDiVertAnalysisConfig(
         input_files=[
@@ -43,7 +45,7 @@ def test_missing_root_files(caplog):
                 output_dir=None,
             )
         ],
-        output_path=Path("./out"),
+        output_path=tmp_path,
         signal_branches=["one"],
         bib_branches=["one"],
         qcd_branches=["one"],
@@ -56,3 +58,41 @@ def test_missing_root_files(caplog):
     # Make sure the log message contains something about zero events.
     assert "one" in caplog.text
     assert "does not contain the required branches" in caplog.text
+
+
+def test_no_redo_existing_file(caplog, tmp_path):
+    "Second run, and nothing should happen"
+
+    default_branches = load_config(ConvertDiVertAnalysisConfig)
+
+    config = ConvertDiVertAnalysisConfig(
+        input_files=[
+            DiVertAnalysisInputFile(
+                input_file=Path("tests/data/short_divert_analysis_file.root"),
+                data_type=DiVertFileType.qcd,
+                output_dir=None,
+            )
+        ],
+        output_path=tmp_path,
+        signal_branches=default_branches.signal_branches,
+        bib_branches=default_branches.bib_branches,
+        qcd_branches=default_branches.qcd_branches,
+        llp_mH=125,
+        llp_mS=100,
+    )
+
+    convert_divert(config)
+
+    # Find the output file
+    output_file = tmp_path / "short_divert_analysis_file.pkl"
+    assert output_file.exists()
+
+    # Next, remove it and replace it with a zero length file, re-run,
+    # and make sure it is still there.
+    output_file.unlink()
+    output_file.touch()
+
+    convert_divert(config)
+
+    assert output_file.exists()
+    assert output_file.stat().st_size == 0


### PR DESCRIPTION
* If the output pkl file already exists, then skip the training. Issue a logging message.

Fixes #78
