### PR TITLE
Default max value of jet pT should be 500 GeV, not 400 GeV

### DIFF
--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -262,7 +262,8 @@ class BuildMainTrainingConfig(BaseModel):
     )
 
     min_jet_pT: Optional[float] = Field(
-        description="The minimum jet pT to use for the training [GeV]."
+        description="The minimum pT to use for the training [GeV]. Applied to jets, "
+        "tracks, etc."
     )
     max_jet_pT: Optional[float] = Field(
         description="The maximum jet pT to use for the training [GeV]."

--- a/cal_ratio_trainer/default_build_main_training_config.yaml
+++ b/cal_ratio_trainer/default_build_main_training_config.yaml
@@ -1,3 +1,3 @@
 output_file: "main_training_file.pkl"
 min_jet_pT: 40
-max_jet_pT: 400
+max_jet_pT: 500


### PR DESCRIPTION
* Change default in the config file
* Add some minor documentation updates to make it clear what it gets used for

Fixes #89