### PR TITLE
Allow filtering at the event level

### DIFF
--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -238,6 +238,10 @@ def build_main_training(config: BuildMainTrainingConfig):
                 next_df is not None
             ), f"Unable to read input files {f_info.input_file}"
 
+            # Filter it
+            if f_info.event_filter is not None:
+                next_df = next_df.query(f_info.event_filter)  # type: ignore
+
             # Now, concat it.
             if file_df is None:
                 file_df = next_df

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -246,7 +246,20 @@ class training_input_file(BaseModel):
     # that match any wildcards. Events kept are randomly sampled from the
     # full set of events.
     num_events: Optional[int] = Field(
-        description="The number of events to include in building the training file."
+        description="The number of events to include in building the training file.",
+        default=None,
+    )
+
+    # An expression that can be applied to the dataframe at the event level to
+    # filter filter events. Use the bar column name. This will need to be a valid
+    # pandas `query` call. For example, odd events only would be "eventNumber % 2 == 1"
+    # A `None` here means no events will be filtered.
+    event_filter: Optional[str] = Field(
+        description="An expression that can be applied to the dataframe at the event "
+        "level to filter filter events. Use the bar column name. This will need to be "
+        "a valid pandas `query` expression. For example, odd events only would be "
+        "'eventNumber % 2 == 1'. A `None` here means no events will be filtered.",
+        default=None,
     )
 
 

--- a/tests/build_training/test_build_main.py
+++ b/tests/build_training/test_build_main.py
@@ -199,3 +199,27 @@ def test_split_by_wild():
         Path("foo/bar"),
         Path("*baz*/*.pkl"),
     )
+
+
+def test_include_only_odd_events(tmp_path):
+    "Test the event filter expression"
+    out_file = tmp_path / "test_output.pkl"
+    c = BuildMainTrainingConfig(
+        input_files=[
+            training_input_file(
+                input_file=Path("tests/data/sig_311424_600_275.pkl"),
+                num_events=None,
+                event_filter="eventNumber % 2 == 1",
+            )
+        ],
+        output_file=out_file,
+        min_jet_pT=30,
+        max_jet_pT=400,
+    )
+
+    build_main_training(c)
+
+    assert out_file.exists()
+    df = pd.read_pickle(out_file)
+    assert len(df[df.eventNumber % 2 == 0]) == 0
+    assert len(df) >= 1


### PR DESCRIPTION
* Allow filtering at the event level
* Use `pandas.DataFrame.query` with the expression comming from the `config` object.

Fixes #94