### PR TITLE
Reorg how the data is getting put together to be built to make it more efficient

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,6 +69,7 @@
         "savefig",
         "scikit",
         "searchsorted",
+        "Segs",
         "shirtballs",
         "sklearn",
         "snakeviz",


### PR DESCRIPTION
This was a first step in trying to address how much memory is getting used when the training file is built. We keep running out.

* Added some logging information
* Do preprocessing on much smaller chunks of data - hopefully this will improve memory and paging issues.

Unfortunately, more clever work is going to need to be done in order to get around the memory problems.

Fixes #96