### PR TITLE
`pandas` is giving lots of vew/copy setting warnings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,7 @@
         "sublists",
         "topocluster",
         "trapz",
+        "vectorize",
         "verticalalignment",
         "xlabel",
         "xlim",

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -167,21 +167,18 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
 
     # Add all etas weighted by pT, then make column that is 1 if positive, -1 if
     # negative
-    df.loc[:, "track_sign"] = np.sum(  # type: ignore
+    track_sign = np.sum(  # type: ignore
         np.multiply(
             df[filter_track_eta].fillna(0).to_numpy(),
             df[filter_track_pt].fillna(0).to_numpy(),
         ),
         axis=1,
     )
-    df.loc[:, "track_sign"] = df["track_sign"].apply(
-        lambda x: 1 * (x >= 0) + (-1) * (x < 0)
-    )
-    # print("3")
+    track_sign = np.vectorize(lambda x: 1 * (x >= 0) + (-1) * (x < 0))(track_sign)
 
     # Flip (multiply by -1) according to previously calculated column
     df.loc[:, filter_track_eta] = df[filter_track_eta].multiply(
-        df["track_sign"], axis="index"
+        track_sign, axis="index"
     )
     # print("4")
 

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -102,7 +102,7 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
         df.loc[:, "sum_eFrac"] = sum_eFrac
 
         df.loc[:, "clus_l1ecal_" + str(i)] = df["clus_l1ecal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l2ecal_" + str(i)] = df["clus_l2ecal_" + str(i)].divide(
             df["sum_eFrac"], axis="index"

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -67,16 +67,15 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
 
     # Add all etas weighted by pT, then make column that is 1 if positive, -1 if
     # negative
-    df.loc[:, "clus_sign"] = np.sum(  # type: ignore
+    cluster_sign = np.sum(  # type: ignore
         np.multiply(
             df[filter_clus_eta].fillna(0).to_numpy(),
             df[filter_clus_pT].fillna(0).to_numpy(),
         ),
         axis=1,
     )
-    df.loc[:, "clus_sign"] = df["clus_sign"].apply(  # type: ignore
-        lambda x: 1 * (x >= 0) + (-1) * (x < 0)
-    )
+    cluster_sign = np.vectorize(lambda x: 1 * (x >= 0) + (-1) * (x < 0))(cluster_sign)
+    df.insert(0, "clus_sign", cluster_sign)
 
     # Flip (multiply by -1) according to previously calculated column
     df.loc[:, filter_clus_eta] = df[filter_clus_eta].multiply(

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -57,11 +57,11 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     filter_clus_pT = [col for col in df if col.startswith("clus_pt")]  # type: ignore
 
     # Subtract the eta of first cluster(largest pT) from all other
-    df[filter_clus_eta] = df[filter_clus_eta].sub(df["clus_eta_0"], axis="index")
+    df.loc[:, filter_clus_eta] = df[filter_clus_eta].sub(df["clus_eta_0"], axis="index")
 
     # Subtract the phi of first cluster(largest pT) from all other
     # TODO: This is a phi wrap-around bug!
-    df[filter_clus_phi] = df[filter_clus_phi].sub(df["clus_phi_0"], axis="index")
+    df.loc[:, filter_clus_phi] = df[filter_clus_phi].sub(df["clus_phi_0"], axis="index")
 
     # Do eta, phi FLIP
 
@@ -79,11 +79,13 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     )
 
     # Flip (multiply by -1) according to previously calculated column
-    df[filter_clus_eta] = df[filter_clus_eta].multiply(df["clus_sign"], axis="index")
+    df.loc[:, filter_clus_eta] = df[filter_clus_eta].multiply(
+        df["clus_sign"], axis="index"
+    )
 
     # SCALE CLUSTER PT
-    df[filter_clus_pT] = df[filter_clus_pT].sub(min_pT, axis="index")
-    df[filter_clus_pT] = df[filter_clus_pT].divide(
+    df.loc[:, filter_clus_pT] = df[filter_clus_pT].sub(min_pT, axis="index")
+    df.loc[:, filter_clus_pT] = df[filter_clus_pT].divide(
         (max_pT * 1000 - min_pT), axis="index"
     )
 

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -99,36 +99,32 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
             if col.startswith("clus_l") and col.endswith(f"_{i}")  # type: ignore
         ]
         sum_eFrac = df[filter_clus_eFrac].sum(axis=1)  # type: ignore
-        df.loc[:, "sum_eFrac"] = sum_eFrac
 
         df.loc[:, "clus_l1ecal_" + str(i)] = df["clus_l1ecal_" + str(i)].divide(
             sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l2ecal_" + str(i)] = df["clus_l2ecal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l3ecal_" + str(i)] = df["clus_l3ecal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l4ecal_" + str(i)] = df["clus_l4ecal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
 
         df.loc[:, "clus_l1hcal_" + str(i)] = df["clus_l1hcal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l2hcal_" + str(i)] = df["clus_l2hcal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l3hcal_" + str(i)] = df["clus_l3hcal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
         df.loc[:, "clus_l4hcal_" + str(i)] = df["clus_l4hcal_" + str(i)].divide(
-            df["sum_eFrac"], axis="index"
+            sum_eFrac, axis="index"
         )
-
-    # Delete calculation variable
-    del df["sum_eFrac"]
 
     # Now For Tracks
     logging.debug("Pre-processing tracks")
@@ -149,7 +145,7 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     # ]
 
     # Subtract the eta of the jet from all tracks
-    df[filter_track_eta] = df[filter_track_eta].sub(df["jet_eta"], axis="index")
+    df.loc[:, filter_track_eta] = df[filter_track_eta].sub(df["jet_eta"], axis="index")
 
     # Subtract the phi of the jet from all tracks
     df[filter_track_phi] = df[filter_track_phi].sub(df["jet_phi"], axis="index")

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -28,13 +28,15 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     ]
 
     # Subtract the eta of the jet from all MSegs
-    df[filter_MSeg_eta] = df[filter_MSeg_eta].sub(df["jet_eta"], axis="index")
+    df.loc[:, filter_MSeg_eta] = df[filter_MSeg_eta].sub(df["jet_eta"], axis="index")
 
     # Subtract the phi of the jet from all MSegs
-    df[filter_MSeg_phi] = df[filter_MSeg_phi].sub(df["jet_phi"], axis="index")
+    df.loc[:, filter_MSeg_phi] = df[filter_MSeg_phi].sub(df["jet_phi"], axis="index")
 
     # Subtract the phi of the jet from all MSegs Dir
-    df[filter_MSeg_phiDir] = df[filter_MSeg_phiDir].sub(df["jet_phi"], axis="index")
+    df.loc[:, filter_MSeg_phiDir] = df[filter_MSeg_phiDir].sub(
+        df["jet_phi"], axis="index"
+    )
 
     logging.debug(f"Pre-processing jets for {min_pT} GeV < pT < {max_pT} GeV")
 

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -148,13 +148,15 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     df.loc[:, filter_track_eta] = df[filter_track_eta].sub(df["jet_eta"], axis="index")
 
     # Subtract the phi of the jet from all tracks
-    df[filter_track_phi] = df[filter_track_phi].sub(df["jet_phi"], axis="index")
+    df.loc[:, filter_track_phi] = df[filter_track_phi].sub(df["jet_phi"], axis="index")
 
     # Do eta, phi FLIP
 
     # SCALE Track PT
-    df[filter_track_pt] = df[filter_track_pt].sub(min_pT, axis="index")
-    df[filter_track_pt] = df[filter_track_pt].divide((max_pT - min_pT), axis="index")
+    df.loc[:, filter_track_pt] = df[filter_track_pt].sub(min_pT, axis="index")
+    df.loc[:, filter_track_pt] = df[filter_track_pt].divide(
+        (max_pT - min_pT), axis="index"
+    )
     # print(df[filter_track_pt])
 
     # df[filter_track_vertex_z] = df[filter_track_vertex_z].divide( (100), axis='index')
@@ -162,7 +164,7 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
 
     # SCALE Track z0
     filter_track_z0 = [col for col in df if col.startswith("track_z0")]  # type: ignore
-    df[filter_track_z0] = df[filter_track_z0].divide(250, axis="index")
+    df.loc[:, filter_track_z0] = df[filter_track_z0].divide(250, axis="index")
     # print("2")
 
     # Add all etas weighted by pT, then make column that is 1 if positive, -1 if
@@ -180,7 +182,9 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     # print("3")
 
     # Flip (multiply by -1) according to previously calculated column
-    df[filter_track_eta] = df[filter_track_eta].multiply(df["track_sign"], axis="index")
+    df.loc[:, filter_track_eta] = df[filter_track_eta].multiply(
+        df["track_sign"], axis="index"
+    )
     # print("4")
 
 

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -75,11 +75,10 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
         axis=1,
     )
     cluster_sign = np.vectorize(lambda x: 1 * (x >= 0) + (-1) * (x < 0))(cluster_sign)
-    df.insert(0, "clus_sign", cluster_sign)
 
     # Flip (multiply by -1) according to previously calculated column
     df.loc[:, filter_clus_eta] = df[filter_clus_eta].multiply(
-        df["clus_sign"], axis="index"
+        cluster_sign, axis="index"
     )
 
     # SCALE CLUSTER PT

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -98,7 +98,8 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
             for col in df
             if col.startswith("clus_l") and col.endswith(f"_{i}")  # type: ignore
         ]
-        df.loc[:, "sum_eFrac"] = df[filter_clus_eFrac].sum(axis=1)  # type: ignore
+        sum_eFrac = df[filter_clus_eFrac].sum(axis=1)  # type: ignore
+        df.loc[:, "sum_eFrac"] = sum_eFrac
 
         df.loc[:, "clus_l1ecal_" + str(i)] = df["clus_l1ecal_" + str(i)].divide(
             df["sum_eFrac"], axis="index"
@@ -125,13 +126,6 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
         df.loc[:, "clus_l4hcal_" + str(i)] = df["clus_l4hcal_" + str(i)].divide(
             df["sum_eFrac"], axis="index"
         )
-
-    # df.loc[filter_clus_eFrac] = df.loc[filter_clus_eFrac]
-    # .divide(df.loc['sum_eFrac'], axis='index')
-
-    # Delete all layer information we used to make l#... variables
-    # for item in layerDelete:
-    # del df[item]
 
     # Delete calculation variable
     del df["sum_eFrac"]

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -253,6 +253,10 @@ def build_main_training(config: BuildMainTrainingConfig):
                     file_df = next_df
                 else:
                     file_df = pd.concat([file_df, next_df])
+                    logging.debug(
+                        f"  Total events for this file: {len(file_df)} "
+                        f"(out of {f_info.num_events} required.)"
+                    )
 
         # If we are limited, resample randomly. And append to the
         # master training file.

--- a/cal_ratio_trainer/common/fileio.py
+++ b/cal_ratio_trainer/common/fileio.py
@@ -63,13 +63,6 @@ def load_dataset(file_url: str, cache: Path) -> pd.DataFrame:
     # here.
     df = df.fillna(0)
 
-    # Delete some 'virtual' variables only needed for pre-processing.
-    # Make sure they exist before deleting them.
-    # TODO: Remove these guys before writing them out too
-    for t_name in ["track_sign", "clus_sign"]:
-        if t_name in df.columns:
-            del df[t_name]
-
     # Delete track_vertex vars in tracks
     # TODO: this should be removed ahead of time.
     vertex_delete = [col for col in df.columns if col.startswith("nn_track_vertex_x")]

--- a/cal_ratio_trainer/common/fileio.py
+++ b/cal_ratio_trainer/common/fileio.py
@@ -63,6 +63,17 @@ def load_dataset(file_url: str, cache: Path) -> pd.DataFrame:
     # here.
     df = df.fillna(0)
 
+    # Delete some 'virtual' variables only needed for pre-processing.
+    # Make sure they exist before deleting them.
+    # These have been removed from the writing, however, if we need
+    # to read old datasets these might still be present. DO not know
+    # how much trouble that will cause downstream, so leaving this in
+    # for now.
+    # TODO: Remove these guys before writing them out too
+    for t_name in ["track_sign", "clus_sign"]:
+        if t_name in df.columns:
+            del df[t_name]
+
     # Delete track_vertex vars in tracks
     # TODO: this should be removed ahead of time.
     vertex_delete = [col for col in df.columns if col.startswith("nn_track_vertex_x")]

--- a/tests/build_training/test_build_main.py
+++ b/tests/build_training/test_build_main.py
@@ -273,13 +273,16 @@ def test_include_bib_file(tmp_path):
 
 
 def test_build_no_copy_view_errors(tmp_path, caplog):
-    logging.basicConfig(level=logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+    # logging.basicConfig(level=logging.DEBUG)
+    # logging.warning("hi")
 
     out_file = tmp_path / "test_output.pkl"
     c = BuildMainTrainingConfig(
         input_files=[
             training_input_file(
-                input_file=Path("tests/data/sig_311424_600_275.pkl"), num_events=None
+                input_file=Path("tests/data/sig_311424_600_275.pkl"),
+                num_events=None,
             )
         ],
         output_file=out_file,
@@ -293,4 +296,4 @@ def test_build_no_copy_view_errors(tmp_path, caplog):
     df = pd.read_pickle(out_file)
     assert len(df) == 76
 
-    assert caplog.text == ""
+    assert "SettingWithCopyWarning" not in caplog.text

--- a/tests/build_training/test_build_main.py
+++ b/tests/build_training/test_build_main.py
@@ -1,10 +1,11 @@
+import logging
 from pathlib import Path
 import pandas as pd
 from cal_ratio_trainer.build.build_main import build_main_training, split_path_by_wild
 from cal_ratio_trainer.config import BuildMainTrainingConfig, training_input_file
 
 
-def test_build_main_one_file(tmp_path):
+def test_build_main_one_file(tmp_path, caplog):
     out_file = tmp_path / "test_output.pkl"
     c = BuildMainTrainingConfig(
         input_files=[
@@ -22,6 +23,8 @@ def test_build_main_one_file(tmp_path):
     assert out_file.exists()
     df = pd.read_pickle(out_file)
     assert len(df) == 76
+
+    assert caplog.text == ""
 
 
 def test_build_main_one_file_ask_for_too_much(tmp_path, caplog):
@@ -267,3 +270,27 @@ def test_include_bib_file(tmp_path):
     assert out_file.exists()
     df = pd.read_pickle(out_file)
     assert len(df) == 558
+
+
+def test_build_no_copy_view_errors(tmp_path, caplog):
+    logging.basicConfig(level=logging.DEBUG)
+
+    out_file = tmp_path / "test_output.pkl"
+    c = BuildMainTrainingConfig(
+        input_files=[
+            training_input_file(
+                input_file=Path("tests/data/sig_311424_600_275.pkl"), num_events=None
+            )
+        ],
+        output_file=out_file,
+        min_jet_pT=30,
+        max_jet_pT=400,
+    )
+
+    build_main_training(c)
+
+    assert out_file.exists()
+    df = pd.read_pickle(out_file)
+    assert len(df) == 76
+
+    assert caplog.text == ""


### PR DESCRIPTION
The `SetViewCopy` warning from `pandas` is caused by updating a column - and not doing it in place. One needs to use `df.loc[:, "column"] = xxx` rather than `df["column"]`. This is to remove all these warnings generated by `pandas` during the `build` process.

* Cleaning this up made the `build` proecss x2 more efficient in memory usage.
* Removed some calculation columns that were just carried along for the rid, but never used.
* Improevd logging so we could better understand how far things were getting before running out of memory.

Fixes #103