### PR TITLE
Test to check for proper column names

### DIFF
--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -13,6 +13,14 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
     # this should be added in for another function
     # And this particular version was copied from Alex.
 
+    # Rename any columns
+    # TODO: Remove this code once understand how this happened upstream.
+    # See issue https://github.com/gordonwatts/CalRatioTrainer/issues/116
+    if "mH" in df.columns:
+        df.rename(columns={"mH": "llp_mH"}, inplace=True)
+    if "mS" in df.columns:
+        df.rename(columns={"mS": "llp_mS"}, inplace=True)
+
     # Check to see if this is zero length.
     if len(df) == 0:
         return df

--- a/tests/build_training/test_build_main.py
+++ b/tests/build_training/test_build_main.py
@@ -27,6 +27,28 @@ def test_build_main_one_file(tmp_path, caplog):
     assert caplog.text == ""
 
 
+def test_build_sig_has_llp_columns(tmp_path, caplog):
+    out_file = tmp_path / "test_output.pkl"
+    c = BuildMainTrainingConfig(
+        input_files=[
+            training_input_file(
+                input_file=Path("tests/data/sig_311424_600_275.pkl"), num_events=None
+            )
+        ],
+        output_file=out_file,
+        min_jet_pT=30,
+        max_jet_pT=400,
+    )
+
+    build_main_training(c)
+
+    assert out_file.exists()
+    df = pd.read_pickle(out_file)
+
+    assert 'llp_mH' in df.columns
+    assert 'llp_mS' in df.columns
+
+
 def test_build_zero_length_file(tmp_path, caplog):
     out_file = tmp_path / "test_output.pkl"
     c = BuildMainTrainingConfig(


### PR DESCRIPTION
Some upstream files are showing up "damaged" - lets put in a quick fix for now, and then fix things upstream later.

* Rename, on the fly, `mS` and `mH` to `llp_mS` and `llp_mH`.

Fixes #114