### PR TITLE
Epic PR to fix small bugs in how we do the conversion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
         "divertanalysis",
         "dphi",
         "dtype",
+        "dtypes",
         "ecal",
         "errorbar",
         "errstate",

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -197,6 +197,18 @@ class DiVertAnalysisInputFile(BaseModel):
         "`output_path` of the master config."
     )
 
+    llp_mH: Optional[float] = Field(
+        description="The mass of the heavy higgs like particle. Zero if not a signal"
+        " file.",
+        default=0.0,
+    )
+
+    llp_mS: Optional[float] = Field(
+        description="The mass of the dark sector light LLP like particle. Zero if not a"
+        " signal file.",
+        default=0.0,
+    )
+
 
 class ConvertDiVertAnalysisConfig(BaseModel):
     "Configuration for converting a divertanalysis output file"
@@ -219,16 +231,6 @@ class ConvertDiVertAnalysisConfig(BaseModel):
     )
     qcd_branches: Optional[List[str]] = Field(
         description="The list of branches to store in the output training file for qcd."
-    )
-
-    llp_mH: Optional[float] = Field(
-        description="The mass of the heavy higgs like particle. Zero if not a signal"
-        " file."
-    )
-
-    llp_mS: Optional[float] = Field(
-        description="The mass of the dark sector light LLP like particle. Zero if not a"
-        " signal file."
     )
 
 

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -353,8 +353,10 @@ def signal_processing(
     return big_df
 
 
-def bib_processing(file, branches: List[str], output_file: Path):
+def bib_processing(file, base_branches: List[str], output_file: Path):
     # need to add in dR calculation
+    extra_branches = ["HLT_jet_isBIB"]
+    branches = base_branches + extra_branches
     bib_data = file["trees_DV_"].arrays(branches)
 
     # tracking if the HLT jet is BIB
@@ -392,6 +394,9 @@ def bib_processing(file, branches: List[str], output_file: Path):
     big_df.insert(0, "llp_mS", 0.0)
     big_df.insert(0, "label", 2)
     big_df["mcEventWeight"] = 1
+
+    # Remove the extra branches we needed for processing
+    big_df = big_df.drop(columns=extra_branches)
 
     big_df.to_pickle(output_file)
 

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -469,12 +469,12 @@ def convert_divert(config: ConvertDiVertAnalysisConfig):
                     # Process according to the data type.
                     if f_info.data_type == "sig":
                         assert config.signal_branches is not None
-                        assert config.llp_mH is not None
-                        assert config.llp_mS is not None
+                        assert f_info.llp_mH is not None
+                        assert f_info.llp_mS is not None
                         signal_processing(
                             in_file,
-                            config.llp_mH,
-                            config.llp_mS,
+                            f_info.llp_mH,
+                            f_info.llp_mS,
                             config.signal_branches,
                             output_file,
                         )

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -299,7 +299,7 @@ def column_guillotine(arr, branches):
 
 
 def signal_processing(
-    signal_file, llp_mH, llp_mS, branches: List[str], output_file: Path
+    signal_file, llp_mH: float, llp_mS: float, branches: List[str], output_file: Path
 ):
     # getting the specific branches as defined by branches
     # should be 'trees_DV_' for every file
@@ -336,11 +336,11 @@ def signal_processing(
     )
 
     # adding in mH and mS columns
-    big_df.insert(0, "llp_mH", llp_mH)
-    big_df.insert(0, "llp_mS", llp_mS)
+    big_df.insert(0, "llp_mH", float(llp_mH))
+    big_df.insert(0, "llp_mS", float(llp_mS))
 
     # creating the label column, filled with 0s because we're working with signal
-    big_df.insert(0, "label", 0)
+    big_df.insert(0, "label", int(0))
 
     # changing the mcEVentWeight to be all 1, matching what Felix does
     big_df["mcEventWeight"] = 1
@@ -382,14 +382,14 @@ def bib_processing(file, branches: List[str], output_file: Path):
     sorted_tcm = sorting_by_pT(dR_masked, branches)
     big_df = column_guillotine(sorted_tcm, branches)
 
-    big_df.insert(0, "llp_Lz", 0)
-    big_df.insert(0, "llp_Lxy", 0)
-    big_df.insert(0, "llp_phi", 0)
-    big_df.insert(0, "llp_eta", 0)
-    big_df.insert(0, "llp_pT", 0)
+    big_df.insert(0, "llp_Lz", 0.0)
+    big_df.insert(0, "llp_Lxy", 0.0)
+    big_df.insert(0, "llp_phi", 0.0)
+    big_df.insert(0, "llp_eta", 0.0)
+    big_df.insert(0, "llp_pT", 0.0)
 
-    big_df.insert(0, "llp_mH", 0)
-    big_df.insert(0, "llp_mS", 0)
+    big_df.insert(0, "llp_mH", 0.0)
+    big_df.insert(0, "llp_mS", 0.0)
     big_df.insert(0, "label", 2)
     big_df["mcEventWeight"] = 1
 
@@ -406,14 +406,14 @@ def qcd_processing(file, branches: List[str], output_file: Path):
     big_df = column_guillotine(sorted, branches)
 
     # Add the extra columns in.
-    big_df.insert(0, "llp_Lz", 0)
-    big_df.insert(0, "llp_Lxy", 0)
-    big_df.insert(0, "llp_phi", 0)
-    big_df.insert(0, "llp_eta", 0)
-    big_df.insert(0, "llp_pT", 0)
+    big_df.insert(0, "llp_Lz", 0.0)
+    big_df.insert(0, "llp_Lxy", 0.0)
+    big_df.insert(0, "llp_phi", 0.0)
+    big_df.insert(0, "llp_eta", 0.0)
+    big_df.insert(0, "llp_pT", 0.0)
 
-    big_df.insert(0, "llp_mH", 0)
-    big_df.insert(0, "llp_mS", 0)
+    big_df.insert(0, "llp_mH", 0.0)
+    big_df.insert(0, "llp_mS", 0.0)
     big_df.insert(0, "label", 1)
 
     big_df.to_pickle(output_file)

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -336,8 +336,8 @@ def signal_processing(
     )
 
     # adding in mH and mS columns
-    big_df.insert(0, "mH", llp_mH)
-    big_df.insert(0, "mS", llp_mS)
+    big_df.insert(0, "llp_mH", llp_mH)
+    big_df.insert(0, "llp_mS", llp_mS)
 
     # creating the label column, filled with 0s because we're working with signal
     big_df.insert(0, "label", 0)
@@ -388,8 +388,8 @@ def bib_processing(file, branches: List[str], output_file: Path):
     big_df.insert(0, "llp_eta", 0)
     big_df.insert(0, "llp_pT", 0)
 
-    big_df.insert(0, "mH", 0)
-    big_df.insert(0, "mS", 0)
+    big_df.insert(0, "llp_mH", 0)
+    big_df.insert(0, "llp_mS", 0)
     big_df.insert(0, "label", 2)
     big_df["mcEventWeight"] = 1
 
@@ -425,8 +425,8 @@ def qcd_processing(file, branches: List[str], output_file: Path):
     big_df.insert(0, "llp_eta", 0)
     big_df.insert(0, "llp_pT", 0)
 
-    big_df.insert(0, "mH", 0)
-    big_df.insert(0, "mS", 0)
+    big_df.insert(0, "llp_mH", 0)
+    big_df.insert(0, "llp_mS", 0)
     big_df.insert(0, "label", 1)
 
     big_df.to_pickle(output_file)

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -405,20 +405,7 @@ def qcd_processing(file, branches: List[str], output_file: Path):
     sorted = sorting_by_pT(jet_masked, branches)
     big_df = column_guillotine(sorted, branches)
 
-    # jet_masked_0 = ak.Array({col: jet_masked[col][:,0] if col.startswith('llp')
-    #                      else jet_masked[col]
-    #                      for col in branches})
-    # jet_masked_1 = ak.Array({col: jet_masked[col][:,1] if col.startswith('llp')
-    #                          else jet_masked[col]
-    #                          for col in branches})
-
-    # sorted_0 = sorting_by_pT(jet_masked_0, branches)
-    # sorted_1 = sorting_by_pT(jet_masked_1, branches)
-
-    # big_df = pd.concat([column_guillotine(sorted_0, branches),
-    # column_guillotine(sorted_1, branches)], axis=0)
-
-    # this order should match order of columns in the signal data
+    # Add the extra columns in.
     big_df.insert(0, "llp_Lz", 0)
     big_df.insert(0, "llp_Lxy", 0)
     big_df.insert(0, "llp_phi", 0)

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -464,6 +464,8 @@ def convert_divert(config: ConvertDiVertAnalysisConfig):
                     # Process according to the data type.
                     if f_info.data_type == "sig":
                         assert config.signal_branches is not None
+                        assert config.llp_mH is not None
+                        assert config.llp_mS is not None
                         signal_processing(
                             in_file,
                             config.llp_mH,

--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -355,7 +355,7 @@ def signal_processing(
 
 def bib_processing(file, base_branches: List[str], output_file: Path):
     # need to add in dR calculation
-    extra_branches = ["HLT_jet_isBIB"]
+    extra_branches = ["HLT_jet_isBIB", "HLT_jet_phi", "HLT_jet_eta"]
     branches = base_branches + extra_branches
     bib_data = file["trees_DV_"].arrays(branches)
 

--- a/cal_ratio_trainer/default_divert_config.yaml
+++ b/cal_ratio_trainer/default_divert_config.yaml
@@ -49,7 +49,6 @@ signal_branches:
   - MSeg_t0
   - MSeg_jetIndex
   - MSeg_chiSquared
-  - HLT_jet_isBIB
   - HLT_jet_eta
   - HLT_jet_phi
   - mcEventWeight
@@ -98,7 +97,6 @@ bib_branches:
   - MSeg_t0
   - MSeg_jetIndex
   - MSeg_chiSquared
-  - HLT_jet_isBIB
   - HLT_jet_eta
   - HLT_jet_phi
   - runNumber
@@ -146,7 +144,6 @@ qcd_branches:
   - MSeg_t0
   - MSeg_jetIndex
   - MSeg_chiSquared
-  - HLT_jet_isBIB
   - HLT_jet_eta
   - HLT_jet_phi
   - mcEventWeight

--- a/cal_ratio_trainer/default_divert_config.yaml
+++ b/cal_ratio_trainer/default_divert_config.yaml
@@ -49,8 +49,6 @@ signal_branches:
   - MSeg_t0
   - MSeg_jetIndex
   - MSeg_chiSquared
-  - HLT_jet_eta
-  - HLT_jet_phi
   - mcEventWeight
   - runNumber
   - eventNumber
@@ -97,8 +95,6 @@ bib_branches:
   - MSeg_t0
   - MSeg_jetIndex
   - MSeg_chiSquared
-  - HLT_jet_eta
-  - HLT_jet_phi
   - runNumber
   - eventNumber
 qcd_branches:
@@ -144,8 +140,6 @@ qcd_branches:
   - MSeg_t0
   - MSeg_jetIndex
   - MSeg_chiSquared
-  - HLT_jet_eta
-  - HLT_jet_phi
   - mcEventWeight
   - runNumber
   - eventNumber

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -166,6 +166,8 @@ def test_bib_file(tmp_path, caplog):
     assert df.dtypes["llp_mH"] == "float64"
     assert df.dtypes["label"] == "int64"
 
+    assert "HLT_jet_isBIB" not in df.columns
+
 
 def test_sig_file(tmp_path, caplog):
     "Make sure a signal file runs correctly"

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -19,14 +19,14 @@ def test_empty_root_files(caplog, tmp_path):
                 input_file=Path("tests/data/empty_divert_analysis_file.root"),
                 data_type=DiVertFileType.bib,
                 output_dir=None,
+                llp_mH=125,
+                llp_mS=100,
             )
         ],
         output_path=tmp_path,
         signal_branches=["one", "two"],
         bib_branches=["three", "four"],
         qcd_branches=["five", "six"],
-        llp_mH=125,
-        llp_mS=100,
     )
 
     convert_divert(config)
@@ -45,14 +45,14 @@ def test_missing_root_files(caplog, tmp_path):
                 input_file=Path("tests/data/short_divert_analysis_file.root"),
                 data_type=DiVertFileType.bib,
                 output_dir=None,
+                llp_mH=0,
+                llp_mS=0,
             )
         ],
         output_path=tmp_path,
         signal_branches=["one"],
         bib_branches=["one"],
         qcd_branches=["one"],
-        llp_mH=125,
-        llp_mS=100,
     )
 
     convert_divert(config)
@@ -73,14 +73,14 @@ def test_no_redo_existing_file(caplog, tmp_path):
                 input_file=Path("tests/data/short_divert_analysis_file.root"),
                 data_type=DiVertFileType.qcd,
                 output_dir=None,
+                llp_mH=0,
+                llp_mS=0,
             )
         ],
         output_path=tmp_path,
         signal_branches=default_branches.signal_branches,
         bib_branches=default_branches.bib_branches,
         qcd_branches=default_branches.qcd_branches,
-        llp_mH=0,
-        llp_mS=0,
     )
 
     convert_divert(config)
@@ -109,14 +109,14 @@ def test_qcd_file(caplog, tmp_path):
                 input_file=Path("tests/data/short_divert_analysis_file.root"),
                 data_type=DiVertFileType.qcd,
                 output_dir=None,
+                llp_mH=0,
+                llp_mS=0,
             )
         ],
         output_path=tmp_path,
         signal_branches=default_branches.signal_branches,
         bib_branches=default_branches.bib_branches,
         qcd_branches=default_branches.qcd_branches,
-        llp_mH=0,
-        llp_mS=0,
     )
 
     convert_divert(config)
@@ -141,14 +141,14 @@ def test_bib_file(tmp_path, caplog):
                 input_file=Path("tests/data/bib.root"),
                 data_type=DiVertFileType.bib,
                 output_dir=None,
+                llp_mH=0,
+                llp_mS=0,
             )
         ],
         output_path=tmp_path,
         signal_branches=default_branches.signal_branches,
         bib_branches=default_branches.bib_branches,
         qcd_branches=default_branches.qcd_branches,
-        llp_mH=0,
-        llp_mS=0,
     )
 
     convert_divert(config)
@@ -180,14 +180,14 @@ def test_sig_file(tmp_path, caplog):
                 input_file=Path("tests/data/sig_311424_600_275.root"),
                 data_type=DiVertFileType.sig,
                 output_dir=None,
+                llp_mH=600,
+                llp_mS=275,
             )
         ],
         output_path=tmp_path,
         signal_branches=default_branches.signal_branches,
         bib_branches=default_branches.bib_branches,
         qcd_branches=default_branches.qcd_branches,
-        llp_mH=600,
-        llp_mS=275,
     )
 
     convert_divert(config)

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -150,8 +150,8 @@ def test_sig_file(tmp_path, caplog):
         signal_branches=default_branches.signal_branches,
         bib_branches=default_branches.bib_branches,
         qcd_branches=default_branches.qcd_branches,
-        llp_mH=0,
-        llp_mS=0,
+        llp_mH=600,
+        llp_mS=275,
     )
 
     convert_divert(config)
@@ -164,3 +164,8 @@ def test_sig_file(tmp_path, caplog):
     df = pd.read_pickle(output_file)
 
     assert len(df) == 76
+    assert "llp_mS" in df.columns
+    assert "llp_mH" in df.columns
+
+    assert df["llp_mS"].unique() == [275]
+    assert df["llp_mH"].unique() == [600]

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -79,8 +79,8 @@ def test_no_redo_existing_file(caplog, tmp_path):
         signal_branches=default_branches.signal_branches,
         bib_branches=default_branches.bib_branches,
         qcd_branches=default_branches.qcd_branches,
-        llp_mH=125,
-        llp_mS=100,
+        llp_mH=0,
+        llp_mS=0,
     )
 
     convert_divert(config)
@@ -98,6 +98,36 @@ def test_no_redo_existing_file(caplog, tmp_path):
 
     assert output_file.exists()
     assert output_file.stat().st_size == 0
+
+
+def test_qcd_file(caplog, tmp_path):
+    default_branches = load_config(ConvertDiVertAnalysisConfig)
+
+    config = ConvertDiVertAnalysisConfig(
+        input_files=[
+            DiVertAnalysisInputFile(
+                input_file=Path("tests/data/short_divert_analysis_file.root"),
+                data_type=DiVertFileType.qcd,
+                output_dir=None,
+            )
+        ],
+        output_path=tmp_path,
+        signal_branches=default_branches.signal_branches,
+        bib_branches=default_branches.bib_branches,
+        qcd_branches=default_branches.qcd_branches,
+        llp_mH=0,
+        llp_mS=0,
+    )
+
+    convert_divert(config)
+
+    # Find the output file
+    output_file = tmp_path / "short_divert_analysis_file.pkl"
+    df = pd.read_pickle(output_file)
+
+    assert df.dtypes["llp_mS"] == "float64"
+    assert df.dtypes["llp_mH"] == "float64"
+    assert df.dtypes["label"] == "int64"
 
 
 def test_bib_file(tmp_path, caplog):
@@ -131,6 +161,10 @@ def test_bib_file(tmp_path, caplog):
     df = pd.read_pickle(output_file)
 
     assert len(df) == 1
+
+    assert df.dtypes["llp_mS"] == "float64"
+    assert df.dtypes["llp_mH"] == "float64"
+    assert df.dtypes["label"] == "int64"
 
 
 def test_sig_file(tmp_path, caplog):
@@ -169,3 +203,7 @@ def test_sig_file(tmp_path, caplog):
 
     assert df["llp_mS"].unique() == [275]
     assert df["llp_mH"].unique() == [600]
+
+    assert df.dtypes["llp_mS"] == "float64"
+    assert df.dtypes["llp_mH"] == "float64"
+    assert df.dtypes["label"] == "int64"

--- a/tests/data/sample_divert_convert.yaml
+++ b/tests/data/sample_divert_convert.yaml
@@ -1,0 +1,481 @@
+input_files:
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361020.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361020.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361021.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361021.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361022.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361022.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361023.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361023.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361024.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361024.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361025.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5W.mc16a.0517.v02_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361025.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5W.mc16a.0517.v02_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361026.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361026.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361027.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361027.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361028.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361028.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361029.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361029.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361030.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361030.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361031.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11W.mc16a.0517.v01_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361031.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11W.mc16a.0517.v01_trees.root
+  - data_type: qcd
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/QCDMC/user.tavandaa.mc16_13TeV.361032.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12W.mc16a.0517.v04_trees.root/*.root
+    mH: 0
+    mS: 0
+    output_dir: user.tavandaa.mc16_13TeV.361032.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12W.mc16a.0517.v04_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16a.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16d.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16e.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16a.0512.v1.jn_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16a.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16a.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16d.0512.v1.jn_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16d.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16d.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16e.0512.v1.jn_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16e.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16e.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311315.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_lthigh.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16a.0512.v1.jn_trees.root/*.root
+    mH: 200
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16a.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16a.0512.v1_trees.root/*.root
+    mH: 200
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16d.0512.v1.jn_trees.root/*.root
+    mH: 200
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16d.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16d.0512.v1_trees.root/*.root
+    mH: 200
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16e.0512.v1.jn_trees.root/*.root
+    mH: 200
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16e.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16e.0512.v1_trees.root/*.root
+    mH: 200
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311419.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH200_mS50.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16a.0512.v1.jn_trees.root/*.root
+    mH: 400
+    mS: 100
+    output_dir: user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16a.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16a.0512.v1_trees.root/*.root
+    mH: 400
+    mS: 100
+    output_dir: user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16d.0512.v1.jn_trees.root/*.root
+    mH: 400
+    mS: 100
+    output_dir: user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16d.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16d.0512.v1_trees.root/*.root
+    mH: 400
+    mS: 100
+    output_dir: user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16e.0512.v1.jn_trees.root/*.root
+    mH: 400
+    mS: 100
+    output_dir: user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16e.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16e.0512.v1_trees.root/*.root
+    mH: 400
+    mS: 100
+    output_dir: user.lcorpe.mc16_13TeV.311420.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH400_mS100.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311422.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_ltlow.mc16a.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311422.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_ltlow.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311422.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_ltlow.mc16d.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311422.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_ltlow.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311422.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_ltlow.mc16e.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311422.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_ltlow.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16a.0512.v1.jn_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16a.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16a.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16d.0512.v1.jn_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16d.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16d.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16e.0512.v1.jn_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16e.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16e.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 150
+    output_dir: user.lcorpe.mc16_13TeV.311423.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS150_lthigh.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311426.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_ltlow.mc16a.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311426.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_ltlow.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311426.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_ltlow.mc16d.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311426.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_ltlow.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311426.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_ltlow.mc16e.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311426.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_ltlow.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16a.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16d.0512.v1.jn_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16d.0512.v1.jn_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16d.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16e.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311427.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS275_lthigh.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311309.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_ltlow.mc16a.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311309.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_ltlow.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311309.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_ltlow.mc16d.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311309.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_ltlow.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311309.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_ltlow.mc16e.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311309.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_ltlow.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311310.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_lthigh.mc16a.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311310.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_lthigh.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311310.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_lthigh.mc16d.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311310.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_lthigh.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311310.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_lthigh.mc16e.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311310.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS5_lthigh.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311312.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_ltlow.mc16a.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311312.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_ltlow.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311312.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_ltlow.mc16d.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311312.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_ltlow.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311312.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_ltlow.mc16e.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311312.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_ltlow.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16a.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16a.0512.v4_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16a.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16d.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16d.0512.v4_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16d.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16e.0512.v1_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16e.0512.v4_trees.root/*.root
+    mH: 125
+    mS: 35
+    output_dir: user.lcorpe.mc16_13TeV.311313.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS35_lthigh.mc16e.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16d.0512.v4_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.lcorpe.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.mc16d.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311417.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS5.mc16a.0512.v1_trees.root/*.root
+    mH: 60
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311417.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS5.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311417.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS5.mc16d.0512.v1_trees.root/*.root
+    mH: 60
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311417.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS5.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311417.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS5.mc16e.0512.v3_trees.root/*.root
+    mH: 60
+    mS: 5
+    output_dir: user.lcorpe.mc16_13TeV.311417.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS5.mc16e.0512.v3_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16a.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16d.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16e.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16e.0512.v4_trees.root/*.root
+    mH: 600
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.mc16e.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16a.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16d.0512.v1_trees.root/*.root
+    mH: 600
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16d.0512.v4_trees.root/*.root
+    mH: 600
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16d.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16e.0512.v3_trees.root/*.root
+    mH: 600
+    mS: 275
+    output_dir: user.lcorpe.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.mc16e.0512.v3_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16a.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16d.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16d.0512.v4_trees.root/*.root
+    mH: 1000
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16d.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16e.0512.v4_trees.root/*.root
+    mH: 1000
+    mS: 50
+    output_dir: user.lcorpe.mc16_13TeV.311425.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS50.mc16e.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16a.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 475
+    output_dir: user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16a.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16a.0512.v4_trees.root/*.root
+    mH: 1000
+    mS: 475
+    output_dir: user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16a.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16d.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 475
+    output_dir: user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16d.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16d.0512.v4_trees.root/*.root
+    mH: 1000
+    mS: 475
+    output_dir: user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16d.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16e.0512.v1_trees.root/*.root
+    mH: 1000
+    mS: 475
+    output_dir: user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16e.0512.v1_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16e.0512.v4_trees.root/*.root
+    mH: 1000
+    mS: 475
+    output_dir: user.lcorpe.mc16_13TeV.311428.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH1000_mS475.mc16e.0512.v4_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.313417.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS16.mc16a.0512.v5.jn.npu_trees.root/*.root
+    mH: 125
+    mS: 16
+    output_dir: user.lcorpe.mc16_13TeV.313417.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS16.mc16a.0512.v5.jn.npu_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.313417.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS16.mc16d.0512.v5.jn.npu_trees.root/*.root
+    mH: 125
+    mS: 16
+    output_dir: user.lcorpe.mc16_13TeV.313417.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS16.mc16d.0512.v5.jn.npu_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.313417.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS16.mc16e.0512.v5.jn.npu_trees.root/*.root
+    mH: 125
+    mS: 16
+    output_dir: user.lcorpe.mc16_13TeV.313417.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS16.mc16e.0512.v5.jn.npu_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.313418.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS16.mc16a.0512.v5.jn.npu_trees.root/*.root
+    mH: 60
+    mS: 16
+    output_dir: user.lcorpe.mc16_13TeV.313418.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS16.mc16a.0512.v5.jn.npu_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.313418.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS16.mc16d.0512.v5.jn.npu_trees.root/*.root
+    mH: 60
+    mS: 16
+    output_dir: user.lcorpe.mc16_13TeV.313418.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS16.mc16d.0512.v5.jn.npu_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.lcorpe.mc16_13TeV.313418.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS16.mc16e.0512.v5.jn.npu_trees.root/*.root
+    mH: 60
+    mS: 16
+    output_dir: user.lcorpe.mc16_13TeV.313418.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH60_mS16.mc16e.0512.v5.jn.npu_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.mproffit.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.651e1e5c_trees.root/*.root
+    mH: 125
+    mS: 55
+    output_dir: user.mproffit.mc16_13TeV.311314.MadGraphPythia8EvtGen_A14NNPDF31LO_HSS_LLP_mH125_mS55_ltlow.651e1e5c_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.mproffit.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.651e1e5c_trees.root/*.root
+    mH: 600
+    mS: 50
+    output_dir: user.mproffit.mc16_13TeV.311421.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS50.651e1e5c_trees.root
+  - data_type: sig
+    input_file: /LLPData/Outputs/DiVertAnaR21/CalRatioOnly/ntups_0512.v1/user.mproffit.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.651e1e5c_trees.root/*.root
+    mH: 600
+    mS: 275
+    output_dir: user.mproffit.mc16_13TeV.311424.MGPy8EG_A14NNPDF23_NNPDF31ME_HSS_LLP_mH600_mS275.651e1e5c_trees.root

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,8 @@
-from cal_ratio_trainer.config import TrainingConfig, load_config
+from cal_ratio_trainer.config import (
+    ConvertDiVertAnalysisConfig,
+    TrainingConfig,
+    load_config,
+)
 from pathlib import Path
 
 
@@ -27,3 +31,15 @@ def test_str():
 def test_url():
     c = load_config(TrainingConfig, Path("tests/test_with_file_url.yaml"))
     assert c.main_training_file == "file:///home/gwatts/junk.pkl"
+
+
+def test_load_divert_convert():
+    c = load_config(
+        ConvertDiVertAnalysisConfig, Path("tests/data/sample_divert_convert.yaml")
+    )
+
+    assert len(c.input_files) > 0
+    signal = [config for config in c.input_files if config["data_type"] == "sig"]
+    assert len(signal) > 0
+
+    assert signal[0]


### PR DESCRIPTION
* Make sure to write `llp_mS` rather than `mS`. Fixes #106
* Remove the `is_HTL_BIB` column requirement. Fixes #81
* Make sure to set types to float64 (like llp_mS, etc.). Fixes #100
* Associate masses with each input file set. Fixes #118