### PR TITLE
During build, have a list of branches we can drop 

### DIFF
--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -230,14 +230,23 @@ def pickle_loader(drop_branches: List[str]) -> Callable[[Path], pd.DataFrame]:
         # TODO: Remove this code once understand how this happened upstream.
         # See issue https://github.com/gordonwatts/CalRatioTrainer/issues/116
         if "mH" in df.columns:
+            logging.warning(
+                "Renaming mH to llp_mH - should not need to happen - old input file?"
+            )
             df.rename(columns={"mH": "llp_mH"}, inplace=True)
         if "mS" in df.columns:
+            logging.warning(
+                "Renaming mS to llp_mS - should not need to happen - old input file?"
+            )
             df.rename(columns={"mS": "llp_mS"}, inplace=True)
 
         # Get rid of branches that should not, perhaps, have been
         # written out in the first place!
         for b in drop_branches:
             if b in df.columns:
+                logging.warning(
+                    f"Dropping branch {b} - should not have been written in first place"
+                )
                 df.drop(columns=b, inplace=True)
 
         return df

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -246,7 +246,8 @@ def pickle_loader(drop_branches: Optional[List[str]]) -> Callable[[Path], pd.Dat
             for b in drop_branches:
                 if b in df.columns:
                     logging.warning(
-                        f"Dropping branch {b} - should not have been written in first place"
+                        f"Dropping branch {b} - should not have been "
+                        "written in first place?"
                     )
                     df.drop(columns=b, inplace=True)
 

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -283,7 +283,9 @@ def build_main_training(config: BuildMainTrainingConfig):
 
         ddf = dd.from_delayed(  # type: ignore
             [
-                dask.delayed(pickle_loader(config.remove_branches))(f_name)  # type: ignore
+                dask.delayed(pickle_loader(config.remove_branches))(  # type: ignore
+                    f_name
+                )
                 for f_name in files_found
             ]
         )

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -212,7 +212,7 @@ def split_path_by_wild(p: Path) -> Tuple[Path, Optional[Path]]:
         return good_path / p.name, None
 
 
-def pickle_loader(drop_branches: List[str]) -> Callable[[Path], pd.DataFrame]:
+def pickle_loader(drop_branches: Optional[List[str]]) -> Callable[[Path], pd.DataFrame]:
     "Create a function that will drop some branches!"
 
     def my_pickle_loader(f: Path) -> pd.DataFrame:
@@ -242,12 +242,13 @@ def pickle_loader(drop_branches: List[str]) -> Callable[[Path], pd.DataFrame]:
 
         # Get rid of branches that should not, perhaps, have been
         # written out in the first place!
-        for b in drop_branches:
-            if b in df.columns:
-                logging.warning(
-                    f"Dropping branch {b} - should not have been written in first place"
-                )
-                df.drop(columns=b, inplace=True)
+        if drop_branches is not None:
+            for b in drop_branches:
+                if b in df.columns:
+                    logging.warning(
+                        f"Dropping branch {b} - should not have been written in first place"
+                    )
+                    df.drop(columns=b, inplace=True)
 
         return df
 

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -9,6 +9,9 @@ from pydantic import BaseModel, Field
 # WARNING:
 # This should include no other modules that eventually import TensorFlow
 # This gets imported in just about every instance, so worth keeping clean.
+# IF you put a default in here, it should be `None`!!! Otherwise the logic
+# will think this is properly set value. Put defaults in the `default_xxx.yaml`
+# files.
 
 
 class TrainingConfig(BaseModel):
@@ -200,13 +203,13 @@ class DiVertAnalysisInputFile(BaseModel):
     llp_mH: Optional[float] = Field(
         description="The mass of the heavy higgs like particle. Zero if not a signal"
         " file.",
-        default=0.0,
+        default=None,
     )
 
     llp_mS: Optional[float] = Field(
         description="The mass of the dark sector light LLP like particle. Zero if not a"
         " signal file.",
-        default=0.0,
+        default=None,
     )
 
 
@@ -283,10 +286,10 @@ class BuildMainTrainingConfig(BaseModel):
     max_jet_pT: Optional[float] = Field(
         description="The maximum jet pT to use for the training [GeV]."
     )
-    remove_branches: List[str] = Field(
+    remove_branches: Optional[List[str]] = Field(
         description="The list of branches to exclude from the training file"
         " (if present).",
-        default=[],
+        default=None,
     )
 
 

--- a/tests/build_training/test_build_main.py
+++ b/tests/build_training/test_build_main.py
@@ -24,7 +24,9 @@ def test_build_main_one_file(tmp_path, caplog):
     df = pd.read_pickle(out_file)
     assert len(df) == 76
 
-    assert caplog.text == ""
+    assert any(
+        "old input files" not in line for line in caplog.text.splitlines()
+    ), f"Failed: {caplog.text}"
 
 
 def test_build_sig_has_llp_columns(tmp_path, caplog):


### PR DESCRIPTION
Add a list of branches - if we spot them, we drop them.

* Main commit was done into `main` directly by accident. Ops.
* Added some logging to indicate when this was triggered.
* Make sure defaults are all `None` - or the logic won't copy them over.

Fixes #122