### PR TITLE
Test cluster pt 0 is written correctly

### DIFF
--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -87,11 +87,11 @@ def pre_process(df: pd.DataFrame, min_pT: float, max_pT: float):
         cluster_sign, axis="index"
     )
 
-    # SCALE CLUSTER PT
-    df.loc[:, filter_clus_pT] = df[filter_clus_pT].sub(min_pT, axis="index")
-    df.loc[:, filter_clus_pT] = df[filter_clus_pT].divide(
-        (max_pT * 1000 - min_pT), axis="index"
-    )
+    # Scale cluster pT by the total cluster pT's
+    def rescale_row_by_sum(row):
+        return row / row.sum()
+
+    df.loc[:, filter_clus_pT] = df[filter_clus_pT].apply(rescale_row_by_sum, axis=1)
 
     logging.debug("Pre-processing cluster energy fraction")
 

--- a/tests/build_training/test_build_main.py
+++ b/tests/build_training/test_build_main.py
@@ -29,6 +29,27 @@ def test_build_main_one_file(tmp_path, caplog):
     ), f"Failed: {caplog.text}"
 
 
+def test_build_clus_pt_0(tmp_path, caplog):
+    out_file = tmp_path / "test_output.pkl"
+    c = BuildMainTrainingConfig(
+        input_files=[
+            training_input_file(
+                input_file=Path("tests/data/sig_311424_600_275.pkl"), num_events=None
+            )
+        ],
+        output_file=out_file,
+        min_jet_pT=30,
+        max_jet_pT=400,
+    )
+
+    build_main_training(c)
+
+    assert out_file.exists()
+    df = pd.read_pickle(out_file)
+    # TODO: if we reverse sorting, then this perhaps should be 0 not 6.
+    assert len(df[df.clus_pt_6 > 0.1]) > 1
+
+
 def test_build_sig_has_llp_columns(tmp_path, caplog):
     out_file = tmp_path / "test_output.pkl"
     c = BuildMainTrainingConfig(

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -277,3 +277,33 @@ def test_sig_eta(tmp_path):
     df = pd.read_pickle(output_file)
 
     assert len(df[abs(df.jet_eta) > 2.0]) > 0
+
+
+def test_cluster_pt(tmp_path):
+    "Make sure we aren't cutting eta tightly"
+
+    default_branches = load_config(ConvertDiVertAnalysisConfig)
+
+    config = ConvertDiVertAnalysisConfig(
+        input_files=[
+            DiVertAnalysisInputFile(
+                input_file=Path("tests/data/sig_311424_600_275.root"),
+                data_type=DiVertFileType.sig,
+                output_dir=None,
+                llp_mH=600,
+                llp_mS=275,
+            )
+        ],
+        output_path=tmp_path,
+        signal_branches=default_branches.signal_branches,
+        bib_branches=default_branches.bib_branches,
+        qcd_branches=default_branches.qcd_branches,
+    )
+
+    convert_divert(config)
+
+    # Check what was written out.
+    output_file = tmp_path / "sig_311424_600_275.pkl"
+    df = pd.read_pickle(output_file)
+
+    assert len(df[df.clus_pt_0 > 0]) > 0

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -237,7 +237,7 @@ def test_sig_file(tmp_path, caplog):
     output_file = tmp_path / "sig_311424_600_275.pkl"
     df = pd.read_pickle(output_file)
 
-    assert len(df) == 76
+    assert len(df) == 91
     assert "llp_mS" in df.columns
     assert "llp_mH" in df.columns
 


### PR DESCRIPTION
* Rescale the `clust_pt_XXX` by the total cluster `p_T`.

Noticed that the sorting seems to be backwards compared to what we might expect - putting the lowest $p_T$ first rather than last in the list. Need to check that is what we want (or not).

Fixes #125