### PR TITLE
Protect against too many tracks, clusters, msegs

### DIFF
--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -293,9 +293,9 @@ def column_guillotine(data: ak.Array) -> pd.DataFrame:
     # awkward alters the type in such a way that `track_list_padded.fields` is
     # an empty type (due to a Union type)
 
-    track_list_padded = ak.pad_none(track_list, 20, axis=1)
-    cluster_list_padded = ak.pad_none(cluster_list, 30, axis=1)
-    mseg_list_padded = ak.pad_none(mseg_list, 30, axis=1)
+    track_list_padded = ak.pad_none(track_list[:, 0:20], 20, axis=1)
+    cluster_list_padded = ak.pad_none(cluster_list[:, 0:30], 30, axis=1)
+    mseg_list_padded = ak.pad_none(mseg_list[:, 0:30], 30, axis=1)  # type: ignore
 
     # Next task is to split the padded arrays into their constituent columns.
     def split_array(array: ak.Array, name_prefix: str) -> pd.DataFrame:

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -170,6 +170,37 @@ def test_qcd_file(caplog, tmp_path):
     assert_columns(df)
 
 
+def test_qcd_bad_slice(caplog, tmp_path):
+    default_branches = load_config(ConvertDiVertAnalysisConfig)
+
+    config = ConvertDiVertAnalysisConfig(
+        input_files=[
+            DiVertAnalysisInputFile(
+                input_file=Path("tests/data/qcd_slice_error.root"),
+                data_type=DiVertFileType.qcd,
+                output_dir=None,
+                llp_mH=0,
+                llp_mS=0,
+            )
+        ],
+        output_path=tmp_path,
+        signal_branches=default_branches.signal_branches,
+        bib_branches=default_branches.bib_branches,
+        qcd_branches=default_branches.qcd_branches,
+        rename_branches=default_branches.rename_branches,
+        min_jet_pt=40,
+        max_jet_pt=500,
+    )
+
+    convert_divert(config)
+
+    # Find the output file
+    output_file = tmp_path / "qcd_slice_error.pkl"
+    df = pd.read_pickle(output_file)
+
+    assert len(df) > 0
+
+
 def test_jet_cuts(caplog, tmp_path):
     default_branches = load_config(ConvertDiVertAnalysisConfig)
 


### PR DESCRIPTION
* If there are more than 20 tracks or more than 30 msegs or clusters, make sure to truncate.

Fixes #138
