### PR TITLE
Cache for pip-install in the github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           uses: actions/cache@v3
           with:
             path: ~/.cache/pip
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/project.toml') }}
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
             restore-keys: |
               ${{ runner.os }}-pip-
         - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,13 @@ jobs:
           uses: actions/setup-python@v4
           with:
             python-version: 3.11
+        - name: Cache pip packages
+          uses: actions/cache@v3
+          with:
+            path: ~/.cache/pip
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/project.toml') }}
+            restore-keys: |
+              ${{ runner.os }}-pip-
         - name: Install dependencies
           run: |
               python -m pip install --upgrade pip


### PR DESCRIPTION
* Implemented using the `actiosn/cache@v3`

While this looks like it is working, we can't save the cache until the CI succeeds more often. So we won't declare #148 fixed just yet.
