### PR TITLE
Use positive and negative Lz distributions

### DIFF
--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -58,7 +58,11 @@ def applying_llp_cuts(llps: ak.Array):
     endcap_llp_eta_mask = abs(llps.eta) > 1.4  # type: ignore
 
     llp_Lxy_mask = (llps.Lxy > 1200) & (llps.Lxy < 4000)  # type: ignore
-    llp_Lz_mask = (llps.Lz > 3500) & (llps.Lz < 6000)  # type: ignore
+    llp_Lz_mask = (llps.Lz > 3500) & (llps.Lz < 6000) | (  # type: ignore
+        llps.Lz < -3500
+    ) & (
+        llps.Lz > -6000
+    )  # type: ignore
 
     llp_mask = (central_llp_eta_mask & llp_Lxy_mask) | (
         endcap_llp_eta_mask & llp_Lz_mask

--- a/tests/convert/test_convert_divert.py
+++ b/tests/convert/test_convert_divert.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import awkward as ak
+import numpy
 import pandas as pd
 import uproot
 
@@ -516,7 +517,7 @@ def test_sig_file(tmp_path, caplog):
     output_file = tmp_path / "sig_311424_600_275.pkl"
     df = pd.read_pickle(output_file)
 
-    assert len(df) == 91
+    assert len(df) == 101
     assert "llp_mS" in df.columns
     assert "llp_mH" in df.columns
 
@@ -548,6 +549,9 @@ def test_sig_file(tmp_path, caplog):
     dR = jets.deltaR(llps)  # type: ignore
 
     assert not ak.any(dR > 0.4)
+
+    # Make sure we have some real negative eta's
+    assert numpy.any(df.jet_eta < -1.5)
 
     assert_columns(df)
 


### PR DESCRIPTION
We were only looking at positive Lz distributions, which was killing the signal at negative eta distributions.

Fixes #161