### PR TITLE
Only plot signal files that are signal file events

### DIFF
--- a/cal_ratio_trainer/reporting/training_file.py
+++ b/cal_ratio_trainer/reporting/training_file.py
@@ -293,6 +293,7 @@ def make_report_plots(cache: Path, config: ReportingConfig):
                             f.data[
                                 (f.data["llp_mH"] == d["llp_mH"])
                                 & (f.data["llp_mS"] == d["llp_mS"])
+                                & (f.data["label"] == EventType.signal.value)
                             ],
                             f"{d['llp_mH']}-{d['llp_mS']}",
                         )

--- a/cal_ratio_trainer/reporting/training_file.py
+++ b/cal_ratio_trainer/reporting/training_file.py
@@ -217,6 +217,7 @@ def make_report_plots(cache: Path, config: ReportingConfig):
                             f.data[
                                 (f.data["llp_mH"] == c_m[0])
                                 & (f.data["llp_mS"] == c_m[1])
+                                & (f.data["label"] == EventType.signal.value)
                             ],
                             f.legend_name,
                         )
@@ -234,7 +235,7 @@ def make_report_plots(cache: Path, config: ReportingConfig):
         report.write("")
 
         # Plot some info per file:
-        report.header("Some file specific information:")
+        report.header("## Some file specific information:")
         for f in files:
             file_type = (
                 "adversary training data"


### PR DESCRIPTION
We were making an assumption that any event with a non-zero $m_S$ or $m_H$ was signal. Turns out not to be the case - Felix's old trianing files seem to have assigned $m_H$ and $m_S$ values to the jet data!

This first filters on the `label` before looking at `llp_mS` or `llp_mH`.

Fixes #172