### PR TITLE
Adjust Lxy and Lz cuts

### DIFF
--- a/cal_ratio_trainer/convert/convert_divert.py
+++ b/cal_ratio_trainer/convert/convert_divert.py
@@ -58,12 +58,10 @@ def applying_llp_cuts(llps: ak.Array):
     central_llp_eta_mask = abs(llps.eta) < 1.4  # type: ignore
     endcap_llp_eta_mask = abs(llps.eta) > 1.4  # type: ignore
 
-    llp_Lxy_mask = (llps.Lxy > 1200) & (llps.Lxy < 4000)  # type: ignore
-    llp_Lz_mask = (llps.Lz > 3500) & (llps.Lz < 6000) | (  # type: ignore
-        llps.Lz < -3500
-    ) & (
-        llps.Lz > -6000
-    )  # type: ignore
+    llp_Lxy_mask = (llps.Lxy > 1500) & (llps.Lxy < 4000)  # type: ignore
+    llp_Lz_mask = ((llps.Lz > 3000) & (llps.Lz < 6000)) | (  # type: ignore
+        (llps.Lz < -3000) & (llps.Lz > -6000)  # type: ignore
+    )
 
     llp_mask = (central_llp_eta_mask & llp_Lxy_mask) | (
         endcap_llp_eta_mask & llp_Lz_mask


### PR DESCRIPTION
* Change Lxy cut to start at 1500 mm rather than 1200.
* Change teh Lz cut to start at 3000 rather than 3500mm.

This will match the training flie, but not the internal note.

Fixes #174
