### PR TITLE
Report plots should use weights

### DIFF
--- a/cal_ratio_trainer/reporting/training_file.py
+++ b/cal_ratio_trainer/reporting/training_file.py
@@ -71,6 +71,7 @@ def make_comparison_plots(
     for data, name in ds_generator:
         ax.hist(
             data[find_column(col_names, data)],
+            weights=data["mcEventWeight"],
             bins=100,
             histtype="step",
             label=name,


### PR DESCRIPTION
* Changed the over-view plots (those that appear at the top level in the report) to use `mcEventWeight`
* Did not change the "all plots" - where a plot for *everything* is made - to use event weights.

Fixes #49