### PR TITLE
Make Failures More Obvious during Running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,4 +90,5 @@ model.keras
 temp_stateful.keras
 temp_stateless.keras
 prof/
-*.root
+/*.root
+/*.pkl

--- a/cal_ratio_trainer/build/build_main.py
+++ b/cal_ratio_trainer/build/build_main.py
@@ -294,7 +294,7 @@ def build_main_training(config: BuildMainTrainingConfig):
         df = file_df if df is None else pd.concat([df, file_df])
         logging.debug(f"  Total events in cumulative dataframe is: {len(df)}")
 
-    assert df is not None
+    assert df is not None, "Failed to add any events to the overall DataFrame"
 
     # Write it out.
     assert config.output_file is not None, "No output file specified"

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -248,6 +248,18 @@ class ConvertDiVertAnalysisConfig(BaseModel):
         description="The maximum jet pT to use for the training [GeV]."
     )
 
+    llp_mH: Optional[float] = Field(
+        description="The default mass of the heavy higgs like particle. Ignored if not a"
+        " signal file. Applied only to files on the command line.",
+        default=0.0,
+    )
+
+    llp_mS: Optional[float] = Field(
+        description="The default mass of the dark sector light LLP like particle. Ignored"
+        " if not a signal file. Applied only to files on the command line.",
+        default=0.0,
+    )
+
 
 class ConvertxAODConfig(BaseModel):
     "Configuration for converting an xAOD file"

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -117,7 +117,11 @@ def do_divert_convert(args):
     if len(args.input_files) > 0:
         a.input_files = [
             DiVertAnalysisInputFile(
-                input_file=f, data_type=args.data_type, output_dir=None
+                input_file=f,
+                data_type=args.data_type,
+                output_dir=None,
+                llp_mH=a.llp_mH,
+                llp_mS=a.llp_mS,
             )
             for f in args.input_files
         ]

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -57,7 +57,7 @@ def do_plot(args):
     if len(args.input_files) > 0:
         input_files: List[plot_file] = []
         for i, f_name in enumerate(args.input_files):
-            assert isinstance(f_name, str)
+            assert isinstance(f_name, str), f"Input file {f_name} is not a string."
             if "=" in f_name:
                 name, f = f_name.split("=", 2)
             else:


### PR DESCRIPTION
* Added better defaults to the `convert divertanalysis` command so that it can easily be run on a divert analysis root file.
* `asserts` that are often badly supplied user data need some sort of error message to help the user
* `logging.debug` statements added at several places to help with tracking down problems.

Fixes #210