### PR TITLE
changed instructions in model-dump to match reality

### DIFF
--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -413,7 +413,7 @@ def main():
     )
     parser_model_dump.add_argument(
         "training",
-        help="The training runs to analyze. Form is <training-name>/<number>/<epoch> "
+        help="The training runs to analyze. Form is <training-name>/<number> "
         "or a path to a JSON file.",
     )
     parser_model_dump.set_defaults(func=do_model_dump)


### PR DESCRIPTION
model-dump only requires `<training-name>/<number>`, instead of `<training-name>/<number>/<epoch>`. Modified -h output to reflect this. 