### PR TITLE
Modified include_high_mass include_low_mass flags

### DIFF
--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -51,11 +51,11 @@ class TrainingConfig(BaseModel):
     mH_parametrization: Optional[bool] = False
     mS_parametrization: Optional[bool] = False
 
-    # Which sets of signal should we include in teh training?
+    # Which sets of signal should we include in the training?
     # TODO: Make this part of the signal file prep - we need something more
     # flexible about what data we include that a bunch of bools like this.
-    include_low_mass: Optional[bool] = False
-    include_high_mass: Optional[bool] = False
+    include_low_mass: Optional[bool] = True
+    include_high_mass: Optional[bool] = True
 
     # The path to the main training data file (signal, qcd, and bib)
     # Use "file:///xxx" to specify a local file with absolute path on linux.

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -413,7 +413,7 @@ def main():
     )
     parser_model_dump.add_argument(
         "training",
-        help="The training runs to analyze. Form is <training-name>/<number>/<epoch> "
+        help="The training runs to analyze. Form is <training-name>/<number> "
         "or a path to a JSON file.",
     )
     parser_model_dump.set_defaults(func=do_model_dump)

--- a/cal_ratio_trainer/utils.py
+++ b/cal_ratio_trainer/utils.py
@@ -80,6 +80,10 @@ def add_config_args(config_class, args: argparse.ArgumentParser) -> None:
                 default=None,
                 help=help_str,
             )
+    # Add flags for including high mass and low mass
+    args.add_argument("--high_mass", action="store_true", help="Include high mass")
+    args.add_argument("--low_mass", action="store_true", help="Include low mass")
+
 
 
 def apply_config_args(config_class: type, config, args):
@@ -105,7 +109,16 @@ def apply_config_args(config_class: type, config, args):
         if getattr(args, prop) is not None:
             setattr(r, prop, getattr(args, prop))
 
+    # Update include_high_mass and include_low_mass based on flags
+    if args.include_high_mass:
+        r.include_high_mass = True
+        r.include_low_mass = False
+    elif args.include_low_mass:
+        r.include_high_mass = False
+        r.include_low_mass = True
+
     return r
+
 
 
 def find_training_result(


### PR DESCRIPTION
Made it so when you call `cr_trainer train --inlcude_high_mass` it makes sets _include_high_mass to true and include_low_mass to false, and vice versa for `cr_trainer train --include_low_mass`. If you just run cr_trainer_train it will have both high mass and low mass training. 