### PR TITLE
Added working scoring function to CLI

### DIFF
--- a/cal_ratio_trainer/common/trained_model.py
+++ b/cal_ratio_trainer/common/trained_model.py
@@ -10,6 +10,7 @@ from keras.models import load_model as load_keras_model
 from keras.models import model_from_json as load_keras_model_from_json
 
 from cal_ratio_trainer.utils import find_training_result
+from cal_ratio_trainer.config import epoch_spec
 
 
 @dataclass
@@ -95,3 +96,15 @@ def load_model(info: str, base_path: Path = Path(".")) -> Model:
     name, run = info.split("/")
     model_dir = find_training_result(name, int(run), base_path)
     return _load_model_only(model_dir)
+
+
+def load_model_from_spec(spec: epoch_spec) -> TrainedModel:
+    """Given a model spec, load the file and return it.
+
+    Args:
+        spec (epoch_spec): The spec which tells us where to load the model from.
+    """
+    model_path = find_training_result(spec.name, spec.run)
+    model = load_trained_model_from_training(model_path, spec.epoch)
+
+    return model

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -182,6 +182,7 @@ class DiVertFileType(str, Enum):
     qcd = "qcd"
     bib = "bib"
 
+
 class ScoreDiVertAnalysisConfig(BaseModel):
     "Configuration to score a particular model on a divert analysis file"
 
@@ -214,6 +215,7 @@ class DiVertAnalysisInputFile(BaseModel):
         " signal file.",
         default=None,
     )
+
 
 class ConvertDiVertAnalysisConfig(BaseModel):
     "Configuration for converting a divertanalysis output file"
@@ -365,6 +367,7 @@ class BuildMainTrainingConfig(BaseModel):
         default=None,
     )
 
+
 class ScorePickleConfig(BaseModel):
     "Configuration to score a particular model on a pickle file"
     input_files: Optional[List[Path]] = Field(
@@ -379,6 +382,7 @@ class ScorePickleConfig(BaseModel):
     training: Optional[epoch_spec] = Field(
         description="The training to use to score the pickle file."
     )
+
 
 config_default_file = {
     TrainingConfig: "default_training_config",

--- a/cal_ratio_trainer/config.py
+++ b/cal_ratio_trainer/config.py
@@ -182,6 +182,9 @@ class DiVertFileType(str, Enum):
     qcd = "qcd"
     bib = "bib"
 
+class ScoreDiVertAnalysisConfig(BaseModel):
+    "Configuration to score a particular model on a divert analysis file"
+
 
 class DiVertAnalysisInputFile(BaseModel):
     "Information about a divertanalysis input file"
@@ -211,7 +214,6 @@ class DiVertAnalysisInputFile(BaseModel):
         " signal file.",
         default=None,
     )
-
 
 class ConvertDiVertAnalysisConfig(BaseModel):
     "Configuration for converting a divertanalysis output file"
@@ -363,6 +365,20 @@ class BuildMainTrainingConfig(BaseModel):
         default=None,
     )
 
+class ScorePickleConfig(BaseModel):
+    "Configuration to score a particular model on a pickle file"
+    input_files: Optional[List[Path]] = Field(
+        description="The list of input pickle to score."
+    )
+
+    output_path: Optional[Path] = Field(
+        description="The path to the directory where the output score pickle files will be "
+        "written. By default current working directory"
+    )
+
+    training: Optional[epoch_spec] = Field(
+        description="The training to use to score the pickle file."
+    )
 
 config_default_file = {
     TrainingConfig: "default_training_config",
@@ -372,4 +388,5 @@ config_default_file = {
     ConvertDiVertAnalysisConfig: "default_divert_config",
     BuildMainTrainingConfig: "default_build_main_training_config",
     ConvertxAODConfig: "default_xaod_config",
+    ScorePickleConfig: "default_score_pickle_config",
 }

--- a/cal_ratio_trainer/default_score_pickle_config.yaml
+++ b/cal_ratio_trainer/default_score_pickle_config.yaml
@@ -1,0 +1,1 @@
+output_path: ./score_report/report.md

--- a/cal_ratio_trainer/reporting/evaluation_utils.py
+++ b/cal_ratio_trainer/reporting/evaluation_utils.py
@@ -3,7 +3,18 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+import logging
+
+from typing import List
+
 from cal_ratio_trainer.common.trained_model import TrainedModelData
+from cal_ratio_trainer.common.column_names import (
+    col_llp_mass_names,
+    col_cluster_names,
+    col_track_names,
+    col_mseg_names,
+    col_jet_names,
+)
 
 
 def load_test_data(run_dir: Path) -> TrainedModelData:
@@ -29,4 +40,75 @@ def load_test_data(run_dir: Path) -> TrainedModelData:
         y=y_data,
         z=z_data,
         weights=list(weights.values()),
+    )
+
+
+def load_test_data_from_df(data: pd.DataFrame) -> TrainedModelData:
+    """
+    Loads test data from a DataFrame and prepares it for model evaluation.
+    Args:
+        data (pd.DataFrame): The DataFrame containing the test data.
+    Returns:
+        TrainedModelData: The prepared test data in the form of TrainedModelData object.
+    """
+
+    # TODO: Fix something upstream to not have to do this anymore
+    data = data.replace(np.nan, 0.0)
+
+    def pull_columns(df: pd.DataFrame, col_list: List[str]) -> np.ndarray:
+        """
+        Extracts the specified columns from a DataFrame and reshapes the resulting array.
+        Args:
+            df (pd.DataFrame): The DataFrame from which to extract columns.
+            col_list (List[str]): The list of column names to extract.
+        Returns:
+            np.ndarray: The reshaped array containing the extracted columns.
+        """
+        df_train = df.loc[:, col_list]
+        logging.debug(f"df_train: {df_train.shape}: {df_train.columns}")
+        train = df_train.values
+
+        # Find the largest value of the integer in column names ending with "_<integer>"
+        # and reshape the inputs so they look like features x depth. If we don't find anything
+        # like that, leave this as a simple array of features.
+        max_index = max(
+            [
+                int(c_name.split("_")[-1])
+                for c_name in col_list
+                if len(c_name.split("_")) > 1 and c_name.split("_")[-1].isdigit()
+            ],
+            default=-1,
+        )
+
+        if max_index > 0:
+            rows = int(len(col_list) / (max_index + 1))
+            assert len(col_list) == rows * (
+                max_index + 1
+            ), f"Found {rows} rows, expected {max_index + 1}"
+
+            return train.reshape(train.shape[0], max_index + 1, rows)
+        else:
+            return train
+
+    cluster_inputs = pull_columns(data, col_cluster_names)
+    logging.debug(f"cluster_inputs: {cluster_inputs.shape}")
+    track_inputs = pull_columns(
+        data, [t for t in col_track_names if "track_Pixel" not in t]
+    )
+    logging.debug(f"track_inputs: {track_inputs.shape}")
+    mseg_inputs = pull_columns(data, col_mseg_names)
+    logging.debug(f"mseg_inputs: {mseg_inputs.shape}")
+    jet_inputs = data.loc[:, col_jet_names].values
+    logging.debug(f"jet_inputs: {jet_inputs.shape}")
+
+    return TrainedModelData(
+        x=[
+            cluster_inputs,
+            track_inputs,
+            mseg_inputs,
+            jet_inputs,
+        ],
+        y=data["label"],
+        z=data[col_llp_mass_names],
+        weights=[data["mcEventWeight"].values],  # type: ignore
     )

--- a/cal_ratio_trainer/score/score_pickle.py
+++ b/cal_ratio_trainer/score/score_pickle.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+import numpy as np
+
+import pandas as pd
+import awkward as ak
+import matplotlib.pyplot as plt
+
+from cal_ratio_trainer.common.trained_model import TrainedModel, load_model_from_spec
+from cal_ratio_trainer.config import ScorePickleConfig
+from cal_ratio_trainer.reporting.evaluation_utils import load_test_data_from_df
+
+
+def _score_pickle_file(model: TrainedModel, file_path: Path):
+    """Run the ML scoring on the data in file_path.
+
+    Args:
+        file_path (Path): The path to the input pickle file.
+    """
+    # Load the data and format it for training. Note
+    # that we assume signal - the label is never used.
+    data = pd.read_pickle(file_path)
+    assert isinstance(data, pd.DataFrame)
+    training_data = load_test_data_from_df(data)
+
+    # Run the prediction
+    predict = model.predict(training_data)
+
+    # Build the output and write it to parquet. For comparison reasons,
+    # we need run, event, jet pt, eta, and phi, along with the three
+    # prediction outputs. We'll create an awkward event.
+    data_dict = {
+        # "run_number": data["run_number"],
+        # "event_number": data["event_number"],
+        "jet_pt": data["jet_pt"],
+        "jet_eta": data["jet_eta"],
+        "jet_phi": data["jet_phi"],
+        "label": data["label"],
+        "jet_nn_qcd": predict[:, 0],
+        "jet_nn_sig": predict[:, 1],
+        "jet_nn_bib": predict[:, 2],
+    }
+
+    ak_data = ak.from_iter(data_dict)
+    ak.to_parquet(ak_data, file_path.parent / f"{file_path.stem}-score.parquet")
+
+    print(predict[:, 0])
+    print(predict[:, 1])
+    print(predict[:, 2])
+    print(f"label 0: { np.sum(predict[:, 0] > 0.1 ) }")
+    print(f"label 1: { np.sum(predict[:, 1] > 0.1 ) }")
+    print(f"label 2: { np.sum(predict[:, 2] > 0.1 ) }")
+    print(f"length: {len(predict[:, 0])}")
+
+    tot_correct = 0
+    for x in predict:
+        if (x[1] > x[0]) & (x[1] > x[2]):
+            tot_correct += 1
+    score = tot_correct / len(predict)
+    print("NN Performance Score - Frac Max Sig ", score)
+
+    tot_correct = 0
+    for x in predict:
+        if x[1] > 0.5:
+            tot_correct += 1
+    score = tot_correct / len(predict)
+    print("NN Performance Score - Frac Sig % > 50 ", score)
+
+    tot_correct = 0
+    for x in predict:
+        if x[1] > 0.8:
+            tot_correct += 1
+    score = tot_correct / len(predict)
+    print("NN Performance Score - Frac Sig % > 80 ", score)
+
+    plot_score(
+        data_dict.get("jet_nn_qcd"),
+        data_dict.get("jet_nn_bib"),
+        data_dict.get("jet_nn_sig"),
+        file_path,
+    )
+
+
+def score_pkl_files(config: ScorePickleConfig):
+    """Score a list of pickle files, writing out
+    parquet files with the scored jets.
+
+    Args:
+        config (ScorePickleConfig): Config describing parameters for the job.
+    """
+    # Load the model for the training we have been given.
+    assert config.training is not None
+
+    # Load the training
+    model = load_model_from_spec(config.training)
+
+    # Run through each file
+    assert config.input_files is not None
+    for f in config.input_files:
+        if not f.exists():
+            raise FileNotFoundError(f"Input file {f} does not exist")
+
+        _score_pickle_file(model, f)
+
+
+def plot_score(qcd_pred, bib_pred, sig_pred, file_path):
+    """
+    Outputs a plot of the 3 different NN scores for the file
+
+    Args:
+        qcd_pred/bib_pred/sig_pred: model prediction for sig/qcd/bib
+    """
+
+    bin_list = np.linspace(0, 1, 30)
+
+    n_qcd, bin_edges_qcd = np.histogram(qcd_pred, bins=bin_list)
+    n_bib, bin_edges_bib = np.histogram(bib_pred, bins=bin_list)
+    n_sig, bin_edges_sig = np.histogram(sig_pred, bins=bin_list)
+
+    n_qcd = n_qcd / np.sum(n_qcd)
+    n_bib = n_bib / np.sum(n_bib)
+    n_sig = n_sig / np.sum(n_sig)
+
+    bin_centers_sig = (bin_edges_sig[:-1] + bin_edges_sig[1:]) / 2.0
+
+    fig, ax = plt.subplots()
+
+    ax.bar(
+        bin_centers_sig,
+        n_sig,
+        width=np.diff(bin_list),
+        color="blue",
+        alpha=0.5,
+        label="SIGNAL NN SCORE",
+        align="center",
+    )
+    bin_centers_qcd = (bin_edges_qcd[:-1] + bin_edges_qcd[1:]) / 2.0
+    ax.errorbar(bin_centers_qcd, n_qcd, fmt="ok", label="QCD NN SCORE")
+    bin_centers_bib = (bin_edges_bib[:-1] + bin_edges_bib[1:]) / 2.0
+    ax.errorbar(bin_centers_bib, n_bib, fmt="ok", mfc="none", label="BIB NN SCORE")
+
+    ax.set_xlabel("NN score", loc="right")
+    ax.set_ylabel("Fraction of Events", loc="top")
+    # ax.set_title("title")
+    # plt.yscale("log")
+    ax.set_xlim(0.00002, 1.0)
+    ax.set_ylim(top=1.2)
+    # ax.set_ylim(top=50)
+    ax.legend(loc="upper right")
+    #
+    plt.savefig(file_path.parent / f"{file_path.stem}-nn_score_plot.png")
+    plt.clf()
+    plt.close(fig)
+
+    return

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -98,7 +98,12 @@ def parse_epoch_spec(spec: str) -> epoch_spec:
     Returns:
         epoch_spec: The parsed specification
     """
-    name, run, epoch = spec.split("/")
+    try:
+        name, run, epoch = spec.split("/")
+    except ValueError:
+        raise ValueError(
+            f"Invalid format for 'spec': {spec!r}. Expected format is 'name/run/epoch'."
+        )
     return epoch_spec(name=name, run=int(run), epoch=int(epoch))
 
 
@@ -168,8 +173,7 @@ def do_xaod_convert(args):
         )
 
     for t in args.add_trainings:
-        name, run, epoch = t.split("/")
-        a.add_training.append(epoch_spec(name=name, run=int(run), epoch=int(epoch)))
+        a.add_training.append(parse_epoch_spec(t))
 
     # And run the conversion.
     from cal_ratio_trainer.convert.convert_xaod import convert_xaod

--- a/cal_ratio_trainer/trainer.py
+++ b/cal_ratio_trainer/trainer.py
@@ -494,30 +494,6 @@ def main():
     add_config_args(ScorePickleConfig, parser_score)
     parser_score.set_defaults(func=do_score_pkl)
 
-    # The `resample` command which takes an input and output training file
-    # and a sampling fraction (0.0-1.0) and resamples the input file to the
-    # output file.
-    parser_rgitesample = subparsers.add_parser(
-        "resample",
-        help="Resample a training (pkl) file by some fraction",
-    )
-    parser_resample.add_argument(
-        "input_file",
-        help="The input file to resample (a URL we can use to get at the file)",
-        type=str,
-    )
-    parser_resample.add_argument(
-        "output_file",
-        help="The output file to write",
-        type=Path,
-    )
-    parser_resample.add_argument(
-        "fraction",
-        help="The fraction of events to keep (value between 0.0 and 1.0)",
-        type=float,
-    )
-    parser_resample.set_defaults(func=do_resample)
-
     # Parse the command line arguments
     args = parser.parse_args()
 


### PR DESCRIPTION
Added a function that will score a trained model on a new signal dataset. Outputs a plot of the qcd/bib/signal NN scores, saves the scores in a parquet file, and also outputs some information about model performance. 